### PR TITLE
Remove use of deprecated case_insensitive parameter

### DIFF
--- a/DataTables.php
+++ b/DataTables.php
@@ -10,7 +10,7 @@
  *  @link      http://editor.datatables.net
  */
 
-define("DATATABLES", true, false);
+define("DATATABLES", true);
 
 //
 // Error checking - check that we are PHP 5.3 or newer

--- a/composer.php
+++ b/composer.php
@@ -9,4 +9,4 @@
  * composer only.
  */
 
-define("DATATABLES", true, false);
+define("DATATABLES", true);


### PR DESCRIPTION
As explained in the [PHP manual](https://www.php.net/manual/en/function.implode.php) the case_insensitive parameter has been deprecated since 7.3 and will be removed entirely in 8.0.0.

The inclusion of it currently causes static code analysis to show a warning and since the flag has been set `false` since [2018](https://github.com/DataTables/Editor-PHP/commit/2ff1ad7b7894743880b2ba04fb129a3ebf6617ec) this would be harmless to remove now.