### PR TITLE
Make abstract methods really abstract

### DIFF
--- a/Database/Query.php
+++ b/Database/Query.php
@@ -36,7 +36,7 @@ use
  * additional methods, but this is discouraged to ensure that the API is the
  * same for all database types.
  */
-class Query {
+abstract class Query {
 	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 	 * Constructor
 	 */
@@ -179,10 +179,7 @@ class Query {
 	 *  @param string $db   Database name
 	 *  @return Query
 	 */
-	public static function connect ( $user, $pass='', $host='', $port='', $db='', $dsn='' )
-	{
-		return false;
-	}
+	abstract public static function connect ( $user, $pass='', $host='', $port='', $db='', $dsn='' );
 
 
 	/**
@@ -979,8 +976,7 @@ class Query {
 	 *  @return Result
 	 *  @internal
 	 */
-	protected function _exec()
-	{}
+	abstract protected function _exec();
 
 	/**
 	 * Create an INSERT statement
@@ -1008,8 +1004,7 @@ class Query {
 	 *  @return void
 	 *  @internal
 	 */
-	protected function _prepare( $sql )
-	{}
+	abstract protected function _prepare( $sql );
 
 	/**
 	 * Protect field names

--- a/Database/Result.php
+++ b/Database/Result.php
@@ -30,7 +30,7 @@ if (!defined('DATATABLES')) exit();
  * additional methods, but this is discouraged to ensure that the API is the
  * same for all database types.
  */
-class Result {
+abstract class Result {
 	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 	 * Public methods
 	 */
@@ -39,10 +39,7 @@ class Result {
 	 * Count the number of rows in the result set.
 	 *  @return int
 	 */
-	public function count ()
-	{
-		return 0;
-	}
+	abstract public function count ();
 
 
 	/**
@@ -50,10 +47,7 @@ class Result {
 	 *  @param int PDO row fetch style - PDO::FETCH_ASSOC is the default
 	 *  @return array
 	 */
-	public function fetch ( $fetchType=\PDO::FETCH_ASSOC )
-	{
-		return array();
-	}
+	abstract public function fetch ( $fetchType=\PDO::FETCH_ASSOC );
 
 
 	/**
@@ -61,20 +55,14 @@ class Result {
 	 *  @param int PDO row fetch style - PDO::FETCH_ASSOC is the default
 	 *  @return array
 	 */
-	public function fetchAll ( $fetchType=\PDO::FETCH_ASSOC )
-	{
-		return array();
-	}
+	abstract public function fetchAll ( $fetchType=\PDO::FETCH_ASSOC );
 
 
 	/**
 	 * After an INSERT query, get the ID that was inserted.
 	 *  @return int
 	 */
-	public function insertId ()
-	{
-		return 0;
-	}
+	abstract public function insertId ();
 };
 
 


### PR DESCRIPTION
not tested, hope the base classes are never used directly and the methods are always implemented everywhere (if not, a php error is good, as the "like abstract defaults" are nonsense)