### PR TITLE
variable $field was overwriting $field param passed to function causing exception

### DIFF
--- a/Editor/SearchPaneOptions.php
+++ b/Editor/SearchPaneOptions.php
@@ -449,13 +449,13 @@ class SearchPaneOptions extends DataTables\Ext {
 			$orderFields = explode( ',', $this->_order );
 
 			for ( $i=0, $ien=count($orderFields) ; $i<$ien ; $i++ ) {
-				$field = strtolower( $orderFields[$i] );
-				$field = str_replace( ' asc', '', $field );
-				$field = str_replace( ' desc', '', $field );
-				$field = trim( $field );
+				$orderField = strtolower( $orderFields[$i] );
+				$orderField = str_replace( ' asc', '', $orderField );
+				$orderField = str_replace( ' desc', '', $orderField );
+				$orderField = trim( $orderField );
 
-				if ( ! in_array( $field, $fields ) ) {
-					$q->get( $field );
+				if ( ! in_array( $orderField, $fields ) ) {
+					$q->get( $orderField );
 				}
 			}
 


### PR DESCRIPTION
from row 452 to 459, variable $field was overwriting $field param passed to exec function making it a string instead o object, so at row 475 $field->name() was throwing exception