### PR TITLE
Remove trailing spaces from all text files

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -51,4 +51,3 @@ spl_autoload_register( function ($class) {
 //   Database connection is globally available
 //
 $db = new Database( $sql_details );
-

--- a/DataTables.php
+++ b/DataTables.php
@@ -27,8 +27,7 @@ if ( version_compare( PHP_VERSION, "5.3.0", '<' ) ) {
 
 
 //
-// Load the DataTables bootstrap core file and let it register the required 
+// Load the DataTables bootstrap core file and let it register the required
 // handlers.
 //
 require( dirname(__FILE__).'/Bootstrap.php' );
-

--- a/Database.php
+++ b/Database.php
@@ -22,10 +22,10 @@ use
  * DataTables Database connection object.
  *
  * Create a database connection which may then have queries performed upon it.
- * 
+ *
  * This is a database abstraction class that can be used on multiple different
  * databases. As a result of this, it might not be suitable to perform complex
- * queries through this interface or vendor specific queries, but everything 
+ * queries through this interface or vendor specific queries, but everything
  * required for basic database interaction is provided through the abstracted
  * methods.
  */
@@ -144,7 +144,7 @@ class Database {
 
 	/**
 	 * Get / set debug mode.
-	 * 
+	 *
 	 *  @param boolean $_ Debug mode state. If not given, then used as a getter.
 	 *  @return boolean|self Debug mode state if no parameter is given, or
 	 *    self if used as a setter.
@@ -470,4 +470,3 @@ class Database {
 		return $this;
 	}
 };
-

--- a/Database/Driver/Db2Result.php
+++ b/Database/Driver/Db2Result.php
@@ -79,4 +79,3 @@ class Db2Result extends Result {
 		return $a;
 	}
 }
-

--- a/Database/Driver/FirebirdQuery.php
+++ b/Database/Driver/FirebirdQuery.php
@@ -75,7 +75,7 @@ class FirebirdQuery extends Query {
 		} catch (\PDOException $e) {
 			// If we can't establish a DB connection then we return a DataTables
 			// error.
-			echo json_encode( array( 
+			echo json_encode( array(
 				"error" => "An error occurred while connecting to the database ".
 					"'{$db}'. The error reported by the server was: ".$e->getMessage()
 			) );
@@ -134,4 +134,3 @@ class FirebirdQuery extends Query {
 		return new FirebirdResult( $resource, $this->_stmt, $this->_pkeyInsertedTo );
 	}
 }
-

--- a/Database/Driver/FirebirdResult.php
+++ b/Database/Driver/FirebirdResult.php
@@ -74,4 +74,3 @@ class FirebirdResult extends Result {
 		return $rows[0][$this->_pkey];
 	}
 }
-

--- a/Database/Driver/MysqlQuery.php
+++ b/Database/Driver/MysqlQuery.php
@@ -63,7 +63,7 @@ class MysqlQuery extends Query {
 		} catch (\PDOException $e) {
 			// If we can't establish a DB connection then we return a DataTables
 			// error.
-			echo json_encode( array( 
+			echo json_encode( array(
 				"error" => "An error occurred while connecting to the database ".
 					"'{$db}'. The error reported by the server was: ".$e->getMessage()
 			) );
@@ -118,4 +118,3 @@ class MysqlQuery extends Query {
 		return new MysqlResult( $resource, $this->_stmt );
 	}
 }
-

--- a/Database/Driver/MysqlResult.php
+++ b/Database/Driver/MysqlResult.php
@@ -70,4 +70,3 @@ class MysqlResult extends Result {
 		return $this->_dbh->lastInsertId();
 	}
 }
-

--- a/Database/Driver/OracleQuery.php
+++ b/Database/Driver/OracleQuery.php
@@ -59,7 +59,7 @@ class OracleQuery extends Query {
 		}
 
 		if ( ! is_callable( 'oci_connect' ) ) {
-			echo json_encode( array( 
+			echo json_encode( array(
 				"error" => "oci methods are not available in this PHP install to connect to Oracle"
 			) );
 			exit(0);
@@ -72,7 +72,7 @@ class OracleQuery extends Query {
 			// error.
 			$e = oci_error();
 
-			echo json_encode( array( 
+			echo json_encode( array(
 				"error" => "An error occurred while connecting to the database ".
 					"'{$db}'. The error reported by the server was: ".$e['message']
 			) );

--- a/Database/Driver/OracleResult.php
+++ b/Database/Driver/OracleResult.php
@@ -79,4 +79,3 @@ class OracleResult extends Result {
 		return $this->_pkey_val;
 	}
 }
-

--- a/Database/Driver/PostgresQuery.php
+++ b/Database/Driver/PostgresQuery.php
@@ -65,7 +65,7 @@ class PostgresQuery extends Query {
 		} catch (\PDOException $e) {
 			// If we can't establish a DB connection then we return a DataTables
 			// error.
-			echo json_encode( array( 
+			echo json_encode( array(
 				"error" => "An error occurred while connecting to the database ".
 					"'{$db}'. The error reported by the server was: ".$e->getMessage()
 			) );
@@ -93,15 +93,15 @@ class PostgresQuery extends Query {
 			$table = explode( ' as ', $this->_table[0] );
 
 			// Get the pkey field name
-			$pkRes = $resource->prepare( 
+			$pkRes = $resource->prepare(
 				"SELECT
-					pg_attribute.attname, 
-					format_type(pg_attribute.atttypid, pg_attribute.atttypmod) 
-				FROM pg_index, pg_class, pg_attribute 
-				WHERE 
+					pg_attribute.attname,
+					format_type(pg_attribute.atttypid, pg_attribute.atttypmod)
+				FROM pg_index, pg_class, pg_attribute
+				WHERE
 					pg_class.oid = '{$table[0]}'::regclass AND
 					indrelid = pg_class.oid AND
-					pg_attribute.attrelid = pg_class.oid AND 
+					pg_attribute.attrelid = pg_class.oid AND
 					pg_attribute.attnum = any(pg_index.indkey)
 					AND indisprimary"
 			);
@@ -143,4 +143,3 @@ class PostgresQuery extends Query {
 		return new PostgresResult( $resource, $this->_stmt );
 	}
 }
-

--- a/Database/Driver/PostgresResult.php
+++ b/Database/Driver/PostgresResult.php
@@ -72,4 +72,3 @@ class PostgresResult extends Result {
 		return $rows[0]['dt_pkey'];
 	}
 }
-

--- a/Database/Driver/SqliteQuery.php
+++ b/Database/Driver/SqliteQuery.php
@@ -58,7 +58,7 @@ class SqliteQuery extends Query {
 		} catch (\PDOException $e) {
 			// If we can't establish a DB connection then we return a DataTables
 			// error.
-			echo json_encode( array( 
+			echo json_encode( array(
 				"error" => "An error occurred while connecting to the database ".
 					"'{$db}'. The error reported by the server was: ".$e->getMessage()
 			) );
@@ -109,4 +109,3 @@ class SqliteQuery extends Query {
 		return new SqliteResult( $resource, $this->_stmt );
 	}
 }
-

--- a/Database/Driver/SqliteResult.php
+++ b/Database/Driver/SqliteResult.php
@@ -70,4 +70,3 @@ class SqliteResult extends Result {
 		return $this->_dbh->lastInsertId();
 	}
 }
-

--- a/Database/Driver/SqlserverQuery.php
+++ b/Database/Driver/SqlserverQuery.php
@@ -79,7 +79,7 @@ class SqlserverQuery extends Query {
 		} catch (\PDOException $e) {
 			// If we can't establish a DB connection then we return a DataTables
 			// error.
-			echo json_encode( array( 
+			echo json_encode( array(
 				"error" => "An error occurred while connecting to the database ".
 					"'{$db}'. The error reported by the server was: ".$e->getMessage()
 			) );
@@ -150,4 +150,3 @@ class SqlserverQuery extends Query {
 		return $out;
 	}
 }
-

--- a/Database/Driver/SqlserverResult.php
+++ b/Database/Driver/SqlserverResult.php
@@ -68,4 +68,3 @@ class SqlserverResult extends Result {
 		return $this->_dbh->lastInsertId();
 	}
 }
-

--- a/Database/Query.php
+++ b/Database/Query.php
@@ -26,7 +26,7 @@ use
 
 /**
  * Perform an individual query on the database.
- * 
+ *
  * The typical pattern for using this class is through the {@see
  * \DataTables\Database->query()} method (and it's 'select', etc short-cuts).
  * Typically it would not be initialised directly.
@@ -515,7 +515,7 @@ abstract class Query {
 	/**
 	 * Order by
 	 *  @param string|string[] $order Columns and direction to order by - can
-	 *    be specified as individual names, an array of names, a string of comma 
+	 *    be specified as individual names, an array of names, a string of comma
 	 *    separated names or any combination of those.
 	 *  @return self
 	 */
@@ -706,14 +706,14 @@ abstract class Query {
 	/**
 	 * Provide grouping for WHERE conditions. Use it with a callback function to
 	 * automatically group any conditions applied inside the method.
-	 * 
+	 *
 	 * For legacy reasons this method also provides the ability to explicitly
 	 * define if a grouping bracket should be opened or closed in the query.
 	 * This method is not prefer.
 	 *
 	 *  @param boolean|callable $inOut If callable it will create the group
 	 *      automatically and pass the query into the called function. For
-	 *      legacy operations use `true` to open brackets, `false` to close. 
+	 *      legacy operations use `true` to open brackets, `false` to close.
 	 *  @param string  $op    Conditional operator to use to join to the
 	 *      preceding condition. Default `AND`.
 	 *  @return self
@@ -744,7 +744,7 @@ abstract class Query {
 	/**
 	 * Provide a method that can be used to perform a `WHERE ... IN (...)` query
 	 * with bound values and parameters.
-	 * 
+	 *
 	 * Note this is only suitable for local values, not a sub-query. For that use
 	 * `->where()` with an unbound value.
 	 *
@@ -778,7 +778,7 @@ abstract class Query {
 			'operator' => $operator,
 			'group'    => null,
 			'field'    => $this->_protect_identifiers($field),
-			'query'    => $this->_protect_identifiers($field) .' IN ('.implode(', ', $binders).')' 
+			'query'    => $this->_protect_identifiers($field) .' IN ('.implode(', ', $binders).')'
 		);
 
 		return $this;
@@ -867,7 +867,7 @@ abstract class Query {
 
 	/**
 	 * Create the GROUP BY string
-	 * 
+	 *
 	 * @return string
 	 * @internal
 	 */
@@ -1009,7 +1009,7 @@ abstract class Query {
 	 */
 	protected function _delete()
 	{
-		$this->_prepare( 
+		$this->_prepare(
 			'DELETE FROM '
 			.$this->_build_table()
 			.$this->_build_where()
@@ -1043,7 +1043,7 @@ abstract class Query {
 	 */
 	protected function _insert()
 	{
-		$this->_prepare( 
+		$this->_prepare(
 			'INSERT INTO '
 				.$this->_build_table().' ('
 					.$this->_build_field()
@@ -1148,7 +1148,7 @@ abstract class Query {
 	 */
 	protected function _select()
 	{
-		$this->_prepare( 
+		$this->_prepare(
 			'SELECT '.($this->_distinct ? 'DISTINCT ' : '')
 			.$this->_build_field( true )
 			.'FROM '.$this->_build_table()
@@ -1173,7 +1173,7 @@ abstract class Query {
 			'SELECT COUNT('.$this->_build_field().') as '.$this->_protect_identifiers('cnt') :
 			'SELECT COUNT('.$this->_build_field().') '.$this->_protect_identifiers('cnt');
 
-		$this->_prepare( 
+		$this->_prepare(
 			$select
 			.' FROM '.$this->_build_table()
 			.$this->_build_join()
@@ -1191,7 +1191,7 @@ abstract class Query {
 	 */
 	protected function _update()
 	{
-		$this->_prepare( 
+		$this->_prepare(
 			'UPDATE '
 			.$this->_build_table()
 			.'SET '.$this->_build_set()
@@ -1291,5 +1291,3 @@ abstract class Query {
 		return array_keys($arr) !== range(0, count($arr) - 1);
 	}
 };
-
-

--- a/Database/Result.php
+++ b/Database/Result.php
@@ -20,7 +20,7 @@ if (!defined('DATATABLES')) exit();
 
 /**
  * Result object given by a {@see Query} performed on a database.
- * 
+ *
  * The typical pattern for using this class is to receive an instance of it as a
  * result of using the {@see Database} and {@see Query} class methods that
  * return a result. This class should not be initialised independently.
@@ -64,5 +64,3 @@ abstract class Result {
 	 */
 	abstract public function insertId ();
 };
-
-

--- a/Editor.php
+++ b/Editor.php
@@ -25,7 +25,7 @@ use
  *
  * Editor class instances are capable of servicing all of the requests that
  * DataTables and Editor will make from the client-side - specifically:
- * 
+ *
  * * Get data
  * * Create new record
  * * Edit existing record
@@ -40,12 +40,12 @@ use
  * the Editor class is used, and how to install Editor on your server, please
  * refer to the {@link https://editor.datatables.net/manual Editor manual}.
  *
- *  @example 
+ *  @example
  *    A very basic example of using Editor to create a table with four fields.
  *    This is all that is needed on the server-side to create a editable
  *    table - the {@see Editor->process()} method determines what action DataTables /
  *    Editor is requesting from the server-side and will correctly action it.
- *    
+ *
  *    ```php
  *      Editor::inst( $db, 'browsers' )
  *          ->fields(
@@ -81,7 +81,7 @@ class Editor extends Ext {
 
 	/**
 	 * Determine the request type from an HTTP request.
-	 * 
+	 *
 	 * @param array $http Typically $_POST, but can be any array used to carry
 	 *   an Editor payload
 	 * @param string $name The parameter name that the action should be read from.
@@ -240,8 +240,8 @@ class Editor extends Ext {
 
 	/**
 	 * Get the data constructed in this instance.
-	 * 
-	 * This will get the PHP array of data that has been constructed for the 
+	 *
+	 * This will get the PHP array of data that has been constructed for the
 	 * command that has been processed by this instance. Therefore only useful after
 	 * process has been called.
 	 *  @return array Processed data array.
@@ -272,11 +272,11 @@ class Editor extends Ext {
 	 * method enables that ability. Information about the queries used is
 	 * automatically added to the output data array / JSON under the property
 	 * name `debugSql`.
-	 * 
+	 *
 	 * This method can also be called with a string parameter, which will be
 	 * added to the debug information sent back to the client-side. This can
 	 * be useful when debugging event listeners, etc.
-	 * 
+	 *
 	 *  @param boolean|mixed $_ Debug mode state. If not given, then used as a
 	 *    getter. If given as anything other than a boolean, it will be added
 	 *    to the debug information sent back to the client.
@@ -302,7 +302,7 @@ class Editor extends Ext {
 
 	/**
 	 * Get / set field instance.
-	 * 
+	 *
 	 * The list of fields designates which columns in the table that Editor will work
 	 * with (both get and set).
 	 *  @param Field|string $_... This parameter effects the return value of the
@@ -343,9 +343,9 @@ class Editor extends Ext {
 
 	/**
 	 * Get / set field instances.
-	 * 
+	 *
 	 * An alias of {@see field}, for convenience.
-	 *  @param Field $_... Instances of the {@see Field} class, given as a single 
+	 *  @param Field $_... Instances of the {@see Field} class, given as a single
 	 *    instance of {@see Field}, an array of {@see Field} instances, or multiple
 	 *    {@see Field} instance parameters for the function.
 	 *  @return Field[]|self Array of fields, or self if used as a setter.
@@ -367,7 +367,7 @@ class Editor extends Ext {
 	 *
 	 * Typically primary keys are numeric and this is not a valid ID value in an
 	 * HTML document - is also increases the likelihood of an ID clash if multiple
-	 * tables are used on a single page. As such, a prefix is assigned to the 
+	 * tables are used on a single page. As such, a prefix is assigned to the
 	 * primary key value for each row, and this is used as the DOM ID, so Editor
 	 * can track individual rows.
 	 *  @param string $_ Primary key's name. If not given, then used as a getter.
@@ -396,7 +396,7 @@ class Editor extends Ext {
 	 * Get / set join instances. Note that for the majority of use cases you
 	 * will want to use the `leftJoin()` method. It is significantly easier
 	 * to use if you are just doing a simple left join!
-	 * 
+	 *
 	 * The list of Join instances that Editor will join the parent table to
 	 * (i.e. the one that the {@see Editor->table()} and {@see Editor->fields}
 	 * methods refer to in this class instance).
@@ -419,13 +419,13 @@ class Editor extends Ext {
 
 	/**
 	 * Get the JSON for the data constructed in this instance.
-	 * 
+	 *
 	 * Basically the same as the {@see Editor->data()} method, but in this case we echo, or
 	 * return the JSON string of the data.
 	 *  @param boolean $print Echo the JSON string out (true, default) or return it
 	 *    (false).
 	 *  @param int JSON encode option https://www.php.net/manual/en/json.constants.php
-	 *  @return string|self self if printing the JSON, or JSON representation of 
+	 *  @return string|self self if printing the JSON, or JSON representation of
 	 *    the processed data if false is given as the first parameter.
 	 */
 	public function json ( $print=true, $options=0 )
@@ -506,11 +506,11 @@ class Editor extends Ext {
 	 * @param string $field2 Field from the child table to use as the join link
 	 * @return self Self for chaining.
 	 *
-	 * @example 
+	 * @example
 	 *    Simple join:
-	 *    
+	 *
 	 *    ```php
-	 *        ->field( 
+	 *        ->field(
 	 *          Field::inst( 'users.first_name as myField' ),
 	 *          Field::inst( 'users.last_name' ),
 	 *          Field::inst( 'users.dept_id' ),
@@ -522,7 +522,7 @@ class Editor extends Ext {
 	 *    ```</code>```
 	 *
 	 *    This is basically the same as the following SQL statement:
-	 * 
+	 *
 	 *    ```sql
 	 *      SELECT users.first_name, users.last_name, user.dept_id, dept.name
 	 *      FROM users
@@ -546,7 +546,7 @@ class Editor extends Ext {
 	 * Indicate if a remove should be performed on left joined tables when deleting
 	 * from the parent row. Note that this is disabled by default and will be
 	 * removed completely in v2. Use `ON DELETE CASCADE` in your database instead.
-	 * 
+	 *
 	 *  @deprecated
 	 *  @param boolean $_ Value to set. If not given, then used as a getter.
 	 *  @return boolean|self Value if no parameter is given, or
@@ -759,7 +759,7 @@ class Editor extends Ext {
 
 	/**
 	 * Get / set the table name.
-	 * 
+	 *
 	 * The table name designated which DB table Editor will use as its data
 	 * source for working with the database. Table names can be given with an
 	 * alias, which can be used to simplify larger table names. The field
@@ -881,9 +881,9 @@ class Editor extends Ext {
 
 	/**
 	 * Where condition to add to the query used to get data from the database.
-	 * 
+	 *
 	 * Can be used in two different ways:
-	 * 
+	 *
 	 * * Simple case: `where( field, value, operator )`
 	 * * Complex: `where( fn )`
 	 *
@@ -898,7 +898,7 @@ class Editor extends Ext {
 	 * using Editor removes the row from the where condition, the result is
 	 * undefined (since Editor expects the row to still be available, but the
 	 * condition removes it from the result set).
-	 * 
+	 *
 	 * @param string|callable $key   Single field name or a closure function
 	 * @param string          $value Single field value.
 	 * @param string          $op    Condition operator: <, >, = etc
@@ -928,7 +928,7 @@ class Editor extends Ext {
 	/**
 	 * Get / set if the WHERE conditions should be included in the create and
 	 * edit actions.
-	 * 
+	 *
 	 *  @param boolean $_ Include (`true`), or not (`false`)
 	 *  @return boolean Current value
 	 *  @deprecated Note that `whereSet` is now deprecated and replaced with the
@@ -1174,8 +1174,8 @@ class Editor extends Ext {
 			}
 		}
 
-		$searchPanes[ 'options' ] = $spOptions; 
-		$searchBuilder[ 'options' ] = $sbOptions; 
+		$searchPanes[ 'options' ] = $spOptions;
+		$searchBuilder[ 'options' ] = $sbOptions;
 
 		// Row based "joins"
 		for ( $i=0 ; $i<count($this->_join) ; $i++ ) {
@@ -1999,7 +1999,7 @@ class Editor extends Ext {
 						for($j=0 ; $j<count($http['searchPanes'][$field->name()]) ; $j++){
 							$q->or_where(
 								$field->dbField(),
-								isset($http['searchPanes_null'][$field->name()][$j]) 
+								isset($http['searchPanes_null'][$field->name()][$j])
 									? null
 									: $http['searchPanes'][$field->name()][$j],
 								'='
@@ -2494,7 +2494,7 @@ class Editor extends Ext {
 
 	/**
 	 * Trigger an event
-	 * 
+	 *
 	 * @private
 	 */
 	private function _trigger ( $eventName, &$arg1=null, &$arg2=null, &$arg3=null, &$arg4=null, &$arg5=null )
@@ -2601,4 +2601,3 @@ class Editor extends Ext {
 			$this->_table;
 	}
 }
-

--- a/Editor/Field.php
+++ b/Editor/Field.php
@@ -24,12 +24,12 @@ use DataTables\HtmLawed\Htmlaw;
 /**
  * Field definitions for the DataTables Editor.
  *
- * Each Database column that is used with Editor can be described with this 
+ * Each Database column that is used with Editor can be described with this
  * Field method (both for Editor and Join instances). It basically tells
  * Editor what table column to use, how to format the data and if you want
  * to read and/or write this column.
  *
- * Field instances are used with the {@see Editor->field()} and 
+ * Field instances are used with the {@see Editor->field()} and
  * {@see Join->field()} methods to describe what fields should be interacted
  * with by the editable table.
  *
@@ -94,7 +94,7 @@ class Field extends DataTables\Ext {
 	function __construct( $dbField=null, $name=null )
 	{
 		if ( $dbField !== null && $name === null ) {
-			// Allow just a single parameter to be passed - each can be 
+			// Allow just a single parameter to be passed - each can be
 			// overridden if needed later using the API.
 			$this->name( $dbField );
 			$this->dbField( $dbField );
@@ -180,7 +180,7 @@ class Field extends DataTables\Ext {
 
 	/**
 	 * Get / set the DB field name.
-	 * 
+	 *
 	 * Note that when used as a setter, an alias can be given for the field
 	 * using the SQL `as` keyword - for example: `firstName as name`. In this
 	 * situation the dbField is set to the field name before the `as`, and the
@@ -263,7 +263,7 @@ class Field extends DataTables\Ext {
 	/**
 	 * Get / set a get value. If given, then this value is used to send to the
 	 * client-side, regardless of what value is held by the database.
-	 * 
+	 *
 	 * @param callable|string|number $_ Value to set, or no value to use as a
 	 *     getter
 	 * @return callable|string|self Value if used as a getter, or self if used
@@ -354,7 +354,7 @@ class Field extends DataTables\Ext {
 
 	/**
 	 * Get a list of values that can be used for the options list in SearchPanes
-	 * 
+	 *
 	 * @param SearchPaneOptions|callable $spInput SearchPaneOptions instance or a closure function if providing a method
 	 * @return self
 	 */
@@ -381,7 +381,7 @@ class Field extends DataTables\Ext {
 
 	/**
 	 * Get a list of values that can be used for the options list in SearchBuilder
-	 * 
+	 *
 	 * @param SearchBuilderOptions|callable $sbInput SearchBuilderOptions instance or a closure function if providing a method
 	 * @return self
 	 */
@@ -418,7 +418,7 @@ class Field extends DataTables\Ext {
 	 *  @param string|boolean $_ Value to set when the method is being used as a
 	 *    setter (leave as undefined to use as a getter). This can take the
 	 *    value of:
-	 *    
+	 *
 	 *    * `true`              - Same as `Field::SET_BOTH`
 	 *    * `false`             - Same as `Field::SET_NONE`
 	 *    * `Field::SET_BOTH`   - Set the database value on both create and edit commands
@@ -473,7 +473,7 @@ class Field extends DataTables\Ext {
 	/**
 	 * Get / set a set value. If given, then this value is used to write to the
 	 * database regardless of what data is sent from the client-side.
-	 * 
+	 *
 	 * @param callable|string|number $_ Value to set, or no value to use as a
 	 *     getter
 	 * @return callable|string|self Value if used as a getter, or self if used
@@ -506,11 +506,11 @@ class Field extends DataTables\Ext {
 	 * Multiple validation options can be applied to a field instance by calling
 	 * this method multiple times. For example, it would be possible to have a
 	 * 'required' validation and a 'maxLength' validation with multiple calls.
-	 * 
+	 *
 	 * Editor has a number of validation available with the {@see Validate} class
 	 * which can be used directly with this method.
 	 *  @param callable|string $_ Value to set if using as the validation method.
-	 *    Can be given as a closure function or a string with a reference to a 
+	 *    Can be given as a closure function or a string with a reference to a
 	 *    function that will be called with call_user_func().
 	 *  @param mixed $opts Variable that is passed through to the validation
 	 *    function - can be useful for passing through extra information such as
@@ -643,7 +643,7 @@ class Field extends DataTables\Ext {
 	/**
 	 * Execute the spopts to get the list of options for SearchPanes to return
 	 * to the client-side
-	 * 
+	 *
 	 * @param DataTables\Field $field The field to retrieve the data from
 	 * @param DataTables\Editor $editor The editor instance
 	 * @param DataTables\DTRequest $http The http request sent to the server
@@ -668,7 +668,7 @@ class Field extends DataTables\Ext {
 	/**
 	 * Execute the spopts to get the list of options for SearchBuilder to return
 	 * to the client-side
-	 * 
+	 *
 	 * @param DataTables\Field $field The field to retrieve the data from
 	 * @param DataTables\Editor $editor The editor instance
 	 * @param DataTables\DTRequest $http The http request sent to the server
@@ -754,7 +754,7 @@ class Field extends DataTables\Ext {
 	 * Called by the Editor / Join class instances - not expected for general
 	 * consumption - internal.
 	 *
-	 * @param array $data Data submitted from the client-side 
+	 * @param array $data Data submitted from the client-side
 	 * @param Editor $editor Editor instance
 	 * @param mixed $id Row id that is being validated
 	 * @return boolean|string `true` if valid, string with error message if not
@@ -958,4 +958,3 @@ class Field extends DataTables\Ext {
 			false;
 	}
 }
-

--- a/Editor/Format.php
+++ b/Editor/Format.php
@@ -16,7 +16,7 @@ if (!defined('DATATABLES')) exit();
 
 /**
  * Formatter methods for the DataTables Editor
- * 
+ *
  * All methods in this class are static with common inputs and returns.
  */
 class Format {
@@ -52,9 +52,9 @@ class Format {
 	 * Convert from SQL date / date time format to a format given by the options
 	 * parameter.
 	 *
-	 * Typical use of this method is to use it with the 
+	 * Typical use of this method is to use it with the
 	 * {@see Field::getFormatter()} and {@see Field::setFormatter()} methods of
-	 * {@see Field} where the parameters required for this method will be 
+	 * {@see Field} where the parameters required for this method will be
 	 * automatically satisfied.
 	 *   @param string $val Value to convert from MySQL date format
 	 *   @param string[] $data Data for the whole row / submitted data
@@ -82,9 +82,9 @@ class Format {
 	 * Convert from a format given by the options parameter to a format that
 	 * SQL servers will recognise as a date.
 	 *
-	 * Typical use of this method is to use it with the 
+	 * Typical use of this method is to use it with the
 	 * {@see Field::getFormatter()} and {@see Field::setFormatter()} methods of
-	 * {@see Field} where the parameters required for this method will be 
+	 * {@see Field} where the parameters required for this method will be
 	 * automatically satisfied.
 	 *   @param string $val Value to convert to SQL date format
 	 *   @param string[] $data Data for the whole row / submitted data
@@ -117,9 +117,9 @@ class Format {
 	/**
 	 * Convert from one date time format to another
 	 *
-	 * Typical use of this method is to use it with the 
+	 * Typical use of this method is to use it with the
 	 * {@see Field::getFormatter()} and {@see Field::setFormatter()} methods of
-	 * {@see Field} where the parameters required for this method will be 
+	 * {@see Field} where the parameters required for this method will be
 	 * automatically satisfied.
 	 *   @param string $val Value to convert
 	 *   @param string[] $data Data for the whole row / submitted data
@@ -343,4 +343,3 @@ class Format {
 		return self::toDecimalChar( $opts );
 	}
 }
-

--- a/Editor/Join.php
+++ b/Editor/Join.php
@@ -25,9 +25,9 @@ use
  * The Join class can be used with {@see Editor->join()} to allow Editor to
  * obtain joined information from the database.
  *
- * For an overview of how Join tables work, please refer to the 
+ * For an overview of how Join tables work, please refer to the
  * {@link https://editor.datatables.net/manual/php/ Editor manual} as it is
- * useful to understand how this class represents the links between tables, 
+ * useful to understand how this class represents the links between tables,
  * before fully getting to grips with it's API.
  *
  *  @example
@@ -66,7 +66,7 @@ class Join extends DataTables\Ext {
 	/**
 	 * Join instance constructor.
 	 *  @param string $table Table name to get the joined data from.
-	 *  @param string $type Work with a single result ('object') or an array of 
+	 *  @param string $type Work with a single result ('object') or an array of
 	 *    results ('array') for the join.
 	 */
 	function __construct( $table=null, $type='object' )
@@ -133,12 +133,12 @@ class Join extends DataTables\Ext {
 	
 	/**
 	 * Get / set parent table alias.
-	 * 
+	 *
 	 * When working with a self referencing table (i.e. a column in the table contains
 	 * a primary key value from its own table) it can be useful to set an alias on the
 	 * parent table's name, allowing a self referencing Join. For example:
 	 *   ```
-	 *   SELECT p2.publisher 
+	 *   SELECT p2.publisher
 	 *   FROM   publisher as p2
 	 *   JOIN   publisher on (publisher.idPublisher = p2.idPublisher)
 	 *   ```
@@ -158,10 +158,10 @@ class Join extends DataTables\Ext {
 
 	/**
 	 * Get / set field instances.
-	 * 
+	 *
 	 * The list of fields designates which columns in the table that will be read
 	 * from the joined table.
-	 *  @param Field $_... Instances of the {@see Field} class, given as a single 
+	 *  @param Field $_... Instances of the {@see Field} class, given as a single
 	 *    instance of {@see Field}, an array of {@see Field} instances, or multiple
 	 *    {@see Field} instance parameters for the function.
 	 *  @return Field[]|self Array of fields, or self if used as a setter.
@@ -180,9 +180,9 @@ class Join extends DataTables\Ext {
 
 	/**
 	 * Get / set field instances.
-	 * 
+	 *
 	 * An alias of {@see field}, for convenience.
-	 *  @param Field $_... Instances of the {@see Field} class, given as a single 
+	 *  @param Field $_... Instances of the {@see Field} class, given as a single
 	 *    instance of {@see Field}, an array of {@see Field} instances, or multiple
 	 *    {@see Field} instance parameters for the function.
 	 *  @return Field[]|self Array of fields, or self if used as a setter.
@@ -201,7 +201,7 @@ class Join extends DataTables\Ext {
 
 	/**
 	 * Get / set get attribute.
-	 * 
+	 *
 	 * When set to false no read operations will occur on the join tables.
 	 *  @param boolean $_ Value
 	 *  @return boolean|self Name
@@ -278,13 +278,13 @@ class Join extends DataTables\Ext {
 	 * Create a join link between two tables. The order of the fields does not
 	 * matter, but each field must contain the table name as well as the field
 	 * name.
-	 * 
+	 *
 	 * This method can be called a maximum of two times for an Mjoin instance:
-	 * 
+	 *
 	 * * First time, creates a link between the Editor host table and a join
 	 *   table
 	 * * Second time creates the links required for a link table.
-	 * 
+	 *
 	 * Please refer to the Editor Mjoin documentation for further details:
 	 * https://editor.datatables.net/manual/php
      *
@@ -327,8 +327,8 @@ class Join extends DataTables\Ext {
 
 	/**
 	 * Get / set name.
-	 * 
-	 * The `name` of the Join is the JSON property key that is used when 
+	 *
+	 * The `name` of the Join is the JSON property key that is used when
 	 * 'getting' the data, and the HTTP property key (in a JSON style) when
 	 * 'setting' data. Typically the name of the db table will be used here,
 	 * but this method allows that to be overridden.
@@ -343,7 +343,7 @@ class Join extends DataTables\Ext {
 
 	/**
 	 * Get / set set attribute.
-	 * 
+	 *
 	 * When set to false no write operations will occur on the join tables.
 	 * This can be useful when you want to display information which is joined,
 	 * but want to only perform write operations on the parent table.
@@ -377,12 +377,12 @@ class Join extends DataTables\Ext {
 
 	/**
 	 * Get / set the join type.
-	 * 
+	 *
 	 * The join type allows the data that is returned from the join to be given
 	 * as an array (i.e. working with multiple possibly results for each record from
 	 * the parent table), or as an object (i.e. working which one and only one result
 	 * for each record form the parent table).
-	 *  @param string $_ Join type ('object') or an array of 
+	 *  @param string $_ Join type ('object') or an array of
 	 *    results ('array') for the join.
 	 *  @return String|self Join type, or self if used as a setter.
 	 */
@@ -414,9 +414,9 @@ class Join extends DataTables\Ext {
 	/**
 	 * Where condition to add to the query used to get data from the database.
 	 * Note that this is applied to the child table.
-	 * 
+	 *
 	 * Can be used in two different ways:
-	 * 
+	 *
 	 * * Simple case: `where( field, value, operator )`
 	 * * Complex: `where( fn )`
 	 *
@@ -449,7 +449,7 @@ class Join extends DataTables\Ext {
 	/**
 	 * Get / set if the WHERE conditions should be included in the create and
 	 * edit actions.
-	 * 
+	 *
 	 * This means that the fields which have been used as part of the 'get'
 	 * WHERE condition (using the `where()` method) will be set as the values
 	 * given.
@@ -553,7 +553,7 @@ class Join extends DataTables\Ext {
 
 			// Check that the joining field is available.  The joining key can
 			// come from the Editor instance's primary key, or any other field,
-			// including a nested value (from a left join). If the instance's 
+			// including a nested value (from a left join). If the instance's
 			// pkey, then we've got that in the DT_RowId parameter, so we can
 			// use that. Otherwise, the key must be in the field list.
 			if ( $this->_propExists( $dteTable.'.'.$joinField, $data[0] ) ) {
@@ -581,7 +581,7 @@ class Join extends DataTables\Ext {
 				$whereIn = array();
 
 				for ( $i=0 ; $i<count($data) ; $i++ ) {
-					$whereIn[] = $pkeyIsJoin ? 
+					$whereIn[] = $pkeyIsJoin ?
 						str_replace( $idPrefix, '', $data[$i]['DT_RowId'] ) :
 						$this->_readProp( $readField, $data[$i] );
 				}
@@ -620,7 +620,7 @@ class Join extends DataTables\Ext {
 
 			// Loop over the data and do a join based on the data available
 			for ( $i=0 ; $i<count($data) ; $i++ ) {
-				$rowPKey = $pkeyIsJoin ? 
+				$rowPKey = $pkeyIsJoin ?
 					str_replace( $idPrefix, '', $data[$i]['DT_RowId'] ) :
 					$this->_readProp( $readField, $data[$i] );
 
@@ -661,7 +661,7 @@ class Join extends DataTables\Ext {
 		// there we do nothing
 		if (
 			! $this->_set ||
-			! isset($data[$this->_name]) || 
+			! isset($data[$this->_name]) ||
 			! isset($data[$this->_name.'-many-count'])
 		) {
 			return;
@@ -866,7 +866,7 @@ class Join extends DataTables\Ext {
 				}
 			}
 
-			$stmt->exec(); 
+			$stmt->exec();
 		}
 	}
 

--- a/Editor/Options.php
+++ b/Editor/Options.php
@@ -143,7 +143,7 @@ class Options extends DataTables\Ext {
 
 	/**
 	 * Set up a left join operation for the options
-	 * 
+	 *
 	 * @param string $table to get the information from
 	 * @param string $field1 the first field to get the information from
 	 * @param string $operator the operation to perform on the two fields
@@ -338,4 +338,3 @@ class Options extends DataTables\Ext {
 		return $out;
 	}
 }
-	

--- a/Editor/SearchBuilderOptions.php
+++ b/Editor/SearchBuilderOptions.php
@@ -181,7 +181,7 @@ class SearchBuilderOptions extends DataTables\Ext {
 	/**
 	 * Get / set the array values used for a leftJoin condition if it is to be
 	 * applied to the query to get the options.
-	 * 
+	 *
 	 * @param string $table to get the information from
 	 * @param string $field1 the first field to get the information from
 	 * @param string $operator the operation to perform on the two fields
@@ -202,7 +202,7 @@ class SearchBuilderOptions extends DataTables\Ext {
 
 	/**
 	 * Adds all of the where conditions to the desired query
-	 * 
+	 *
 	 * @param string $query the query being built
 	 * @return self
 	 */
@@ -332,4 +332,3 @@ class SearchBuilderOptions extends DataTables\Ext {
 		return $out;
 	}
 }
-	

--- a/Editor/SearchPaneOptions.php
+++ b/Editor/SearchPaneOptions.php
@@ -181,7 +181,7 @@ class SearchPaneOptions extends DataTables\Ext {
 	/**
 	 * Get / set the array values used for a leftJoin condition if it is to be
 	 * applied to the query to get the options.
-	 * 
+	 *
 	 * @param string $table to get the information from
 	 * @param string $field1 the first field to get the information from
 	 * @param string $operator the operation to perform on the two fields
@@ -202,7 +202,7 @@ class SearchPaneOptions extends DataTables\Ext {
 
 	/**
 	 * Adds all of the where conditions to the desired query
-	 * 
+	 *
 	 * @param string $query the query being built
 	 * @return self
 	 */
@@ -394,7 +394,7 @@ class SearchPaneOptions extends DataTables\Ext {
 						for($j=0, $jen=count($http['searchPanes'][$fieldName]); $j < $jen ; $j++) {
 							$q->or_where(
 								$fieldOpt->dbField(),
-								isset($http['searchPanes_null'][$fieldName][$j]) 
+								isset($http['searchPanes_null'][$fieldName][$j])
 									? null
 									: $http['searchPanes'][$fieldName][$j],
 								'='
@@ -464,4 +464,3 @@ class SearchPaneOptions extends DataTables\Ext {
 		return $out;
 	}
 }
-	

--- a/Editor/Upload.php
+++ b/Editor/Upload.php
@@ -36,8 +36,8 @@ use DataTables;
  *
  * Both methods are optional - you can store the file on the server using the
  * {@see Upload->db()} method only if you want to store the file in the database, or if
- * you don't want to store relational data on the database us only 
- * {@see Upload->action()}. However,  the majority of the time it is best to use 
+ * you don't want to store relational data on the database us only
+ * {@see Upload->action()}. However,  the majority of the time it is best to use
  * both - store information about the file on the database for fast retrieval (using a
  * {@see Editor->leftJoin()} for example) and the file on the file system for direct
  * web access.
@@ -106,7 +106,7 @@ class Upload extends DataTables\Ext {
 	/** Database value option (`Db()`) - Full system path to the file */
 	const DB_SYSTEM_PATH  = 'editor-systemPath';
 
-	/** Database value option (`Db()`) - HTTP path to the file. This is derived 
+	/** Database value option (`Db()`) - HTTP path to the file. This is derived
 	 * from the system path by removing `$_SERVER['DOCUMENT_ROOT']`. If your
 	 * images live outside of the document root a custom value would be to be
 	 * used.
@@ -172,7 +172,7 @@ class Upload extends DataTables\Ext {
 	 *   with the uploaded file is transferred to this function. That will
 	 *   typically involve writing it to the file system so it can be used
 	 *   later.
-	 * 
+	 *
 	 * @param  string|callable $action Action to take - see description above.
 	 * @return self Current instance, used for chaining
 	 */
@@ -381,7 +381,7 @@ class Upload extends DataTables\Ext {
 
 	/**
 	 * Get the set error message
-	 * 
+	 *
 	 * @return string Class error
 	 * @internal
 	 */
@@ -406,7 +406,7 @@ class Upload extends DataTables\Ext {
 		// Validation - PHP standard validation
 		if ( $upload['error'] !== UPLOAD_ERR_OK ) {
 			if ( $upload['error'] === UPLOAD_ERR_INI_SIZE ) {
-				$this->_error = "File exceeds maximum file upload size"; 
+				$this->_error = "File exceeds maximum file upload size";
 			}
 			else {
 				$this->_error = "There was an error uploading the file (".$upload['error'].")";
@@ -648,7 +648,7 @@ class Upload extends DataTables\Ext {
 
 				case self::DB_SYSTEM_PATH:
 					$pathFields[ $column ] = self::DB_SYSTEM_PATH;
-					$q->set( $column, '-' ); // Use a temporary value to avoid cases 
+					$q->set( $column, '-' ); // Use a temporary value to avoid cases
 					break;                   // where the db will reject empty values
 
 				case self::DB_WEB_PATH:
@@ -732,4 +732,3 @@ class Upload extends DataTables\Ext {
 		return $to;
 	}
 }
-

--- a/Editor/Validate.php
+++ b/Editor/Validate.php
@@ -126,7 +126,7 @@ class Validate {
 				return 'This field is required';
 			}
 
-			return call_user_func_array( 
+			return call_user_func_array(
 				__NAMESPACE__.'\Validate::'.str_replace( '_required', '', $name ),
 				$arguments
 			);
@@ -160,7 +160,7 @@ class Validate {
 
 		// Merge into a single array - first array gets priority if there is a
 		// key clash, so user first, then function commands and finally the
-		// global options 
+		// global options
 		$cfg = $userOpts + $fnOpts + $cfg;
 
 		return $cfg;
@@ -300,13 +300,13 @@ class Validate {
 	 * Required field - there must be a value and it must be a non-empty value
 	 *
 	 * This is a helper short-cut method which is the same as:
-	 * 
+	 *
 	 * ```
 	 * Validate::basic( $val, $data, array(
 	 *   "required" => true
 	 * );
 	 * ```
-	 * 
+	 *
 	 *  @param string $val The value to check for validity
 	 *  @param string[] $data The full data set submitted
 	 *  @param array $opts Validation options. No additional options are
@@ -334,7 +334,7 @@ class Validate {
 	 * Optional field, but if given there must be a non-empty value
 	 *
 	 * This is a helper short-cut method which is the same as:
-	 * 
+	 *
 	 * ```
 	 * Validate::basic( $val, $data, array(
 	 *   "empty" => false
@@ -984,7 +984,7 @@ class Validate {
 
 			return $res->count() === 0 ?
 				true :
-				$opts->message(); 
+				$opts->message();
 		};
 	}
 
@@ -1393,4 +1393,3 @@ class Validate {
 		return Validate::dbValues( $opts, $column, $table, $db, $values );
 	}
 }
-

--- a/Editor/ValidateOptions.php
+++ b/Editor/ValidateOptions.php
@@ -39,7 +39,7 @@ class ValidateOptions extends DataTables\Ext {
 
         return $this;
     }
-    
+
     /**
      * Get / set the error message to use if validation fails
      * @param string $msg Error message to use. If not given, the currently
@@ -54,7 +54,7 @@ class ValidateOptions extends DataTables\Ext {
         $this->_message = $msg;
         return $this;
     }
-    
+
     /**
      * Get / set the field empty option
      * @param boolean $empty `false` if the field is not allowed to be
@@ -69,7 +69,7 @@ class ValidateOptions extends DataTables\Ext {
         $this->_empty = $empty;
         return $this;
     }
-    
+
     /**
      * Get / set the field optional option
      * @param boolean $optional `false` if the field does not need to be

--- a/Ext.php
+++ b/Ext.php
@@ -40,7 +40,7 @@ class Ext {
 	}
 
 	/**
-	 * Static method to instantiate a new instance of a class (shorthand of 
+	 * Static method to instantiate a new instance of a class (shorthand of
 	 * 'instantiate').
 	 *
 	 * This method performs exactly the same actions as the 'instantiate'
@@ -219,4 +219,3 @@ class Ext {
 		$inner[ $names[count($names)-1] ] = $value;
 	}
 }
-

--- a/HtmLawed/Htmlaw.php
+++ b/HtmLawed/Htmlaw.php
@@ -3,9 +3,9 @@
  * HtmLawed is used here to provide protection against XSS attacks with Editor
  * input - see the `Field->xss()` method. The Vanilla forums wrapper is used
  * to provide sensible defaults and a clean interface for HtmLawed.
- * 
+ *
  * Changes:
- * 
+ *
  *  * Add `DataTables/HtmLawed` namespace to this and htmLawed - this is to ensure
  *    that if htmLawed is included by any other aspect of the site it will not
  *    result in a conflict.
@@ -16,7 +16,7 @@
  *  * Update all `htmLawed::` references to `\DataTables\HtmLawed\HtmLawed::` in
  *    the htmLawed file (to allow callbacks to operate correctly)
  *  * Updated Vanilla wrapper to operate on PHP 5.3
- * 
+ *
  * HtmLawed:
  *   http://www.bioinformatics.org/phplabware/internal_utilities/htmLawed/
  *   Copyright: Santosh Patnaik

--- a/HtmLawed/Htmlawed.php
+++ b/HtmLawed/Htmlawed.php
@@ -36,20 +36,20 @@ class Htmlawed {
     public static function hl($t, $C=1, $S=array())
     {
       // Standard elements including deprecated.
-  
+
       $eleAr = array('a'=>1, 'abbr'=>1, 'acronym'=>1, 'address'=>1, 'applet'=>1, 'area'=>1, 'article'=>1, 'aside'=>1, 'audio'=>1, 'b'=>1, 'bdi'=>1, 'bdo'=>1, 'big'=>1, 'blockquote'=>1, 'br'=>1, 'button'=>1, 'canvas'=>1, 'caption'=>1, 'center'=>1, 'cite'=>1, 'code'=>1, 'col'=>1, 'colgroup'=>1, 'command'=>1, 'data'=>1, 'datalist'=>1, 'dd'=>1, 'del'=>1, 'details'=>1, 'dialog'=>1, 'dfn'=>1, 'dir'=>1, 'div'=>1, 'dl'=>1, 'dt'=>1, 'em'=>1, 'embed'=>1, 'fieldset'=>1, 'figcaption'=>1, 'figure'=>1, 'font'=>1, 'footer'=>1, 'form'=>1, 'h1'=>1, 'h2'=>1, 'h3'=>1, 'h4'=>1, 'h5'=>1, 'h6'=>1, 'header'=>1, 'hgroup'=>1, 'hr'=>1, 'i'=>1, 'iframe'=>1, 'img'=>1, 'input'=>1, 'ins'=>1, 'isindex'=>1, 'kbd'=>1, 'keygen'=>1, 'label'=>1, 'legend'=>1, 'li'=>1, 'link'=>1, 'main'=>1, 'map'=>1, 'mark'=>1, 'menu'=>1, 'meta'=>1, 'meter'=>1, 'nav'=>1, 'noscript'=>1, 'object'=>1, 'ol'=>1, 'optgroup'=>1, 'option'=>1, 'output'=>1, 'p'=>1, 'param'=>1, 'picture'=>1, 'pre'=>1, 'progress'=>1, 'q'=>1, 'rb'=>1, 'rbc'=>1, 'rp'=>1, 'rt'=>1, 'rtc'=>1, 'ruby'=>1, 's'=>1, 'samp'=>1, 'script'=>1, 'section'=>1, 'select'=>1, 'slot'=>1, 'small'=>1, 'source'=>1, 'span'=>1, 'strike'=>1, 'strong'=>1, 'style'=>1, 'sub'=>1, 'summary'=>1, 'sup'=>1, 'table'=>1, 'tbody'=>1, 'td'=>1, 'template'=>1, 'textarea'=>1, 'tfoot'=>1, 'th'=>1, 'thead'=>1, 'time'=>1, 'tr'=>1, 'track'=>1, 'tt'=>1, 'u'=>1, 'ul'=>1, 'var'=>1, 'video'=>1, 'wbr'=>1);
-  
+
       // Set $C array ($config), using default parameters as needed.
-  
+
       $C = is_array($C) ? $C : array();
       if (!empty($C['valid_xhtml'])) {
         $C['elements'] = empty($C['elements']) ? '*-acronym-big-center-dir-font-isindex-s-strike-tt' : $C['elements'];
         $C['make_tag_strict'] = isset($C['make_tag_strict']) ? $C['make_tag_strict'] : 2;
         $C['xml:lang'] = isset($C['xml:lang']) ? $C['xml:lang'] : 2;
       }
-  
+
       // -- Configure for elements.
-  
+
       if (!empty($C['safe'])) {
         unset($eleAr['applet'], $eleAr['audio'], $eleAr['canvas'], $eleAr['dialog'], $eleAr['embed'], $eleAr['iframe'], $eleAr['object'], $eleAr['script'], $eleAr['video']);
       }
@@ -88,9 +88,9 @@ class Htmlawed {
         }
       }
       $C['elements'] =& $eleAr;
-  
+
       // -- Configure for attributes.
-  
+
       $x = !empty($C['deny_attribute']) ? strtolower(preg_replace('"\s+-"', '/', trim($C['deny_attribute']))) : '';
       $x = str_replace(array(' ', "\t", "\r", "\n"), '', $x);
       $x =
@@ -104,9 +104,9 @@ class Htmlawed {
                  (!empty($C['safe']) ? preg_replace('`/on[^/]+`', '', $x) : $x)))
            : array_filter(explode(',', $x. (!empty($C['safe']) ? ',on*' : ''))));
       $C['deny_attribute'] = $x;
-  
+
       // -- Configure URL handling.
-  
+
       $x = (isset($C['schemes'][2]) && strpos($C['schemes'], ':')
             ? strtolower($C['schemes'])
             : 'href: aim, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, sftp, ssh, tel, telnet')
@@ -134,9 +134,9 @@ class Htmlawed {
       if (!isset($C['base_url']) || !preg_match('`^[a-zA-Z\d.+\-]+://[^/]+/(.+?/)?$`', $C['base_url'])) {
         $C['base_url'] = $C['abs_url'] = 0;
       }
-  
+
       // -- Configure other parameters.
-  
+
       $C['and_mark'] = empty($C['and_mark']) ? 0 : 1;
       $C['anti_link_spam'] =
         (isset($C['anti_link_spam'])
@@ -170,22 +170,22 @@ class Htmlawed {
       $C['tidy'] = empty($C['tidy']) ? 0 : $C['tidy'];
       $C['unique_ids'] = isset($C['unique_ids']) && (!preg_match('`\W`', $C['unique_ids'])) ? $C['unique_ids'] : 1;
       $C['xml:lang'] = isset($C['xml:lang']) ? $C['xml:lang'] : 0;
-  
+
       if (isset($GLOBALS['C'])) {
         $oldC = $GLOBALS['C'];
       }
       $GLOBALS['C'] = $C;
-  
+
       // Set $S array ($spec).
-  
+
       $S = is_array($S) ? $S : self::hl_spec($S);
       if (isset($GLOBALS['S'])) {
         $oldS = $GLOBALS['S'];
       }
       $GLOBALS['S'] = $S;
-  
+
       // Handle characters.
-  
+
       $t = preg_replace('`[\x00-\x08\x0b-\x0c\x0e-\x1f]`', '', $t); // Remove illegal
       if ($C['clean_ms_char']) { // Convert MS Windows CP-1252
         $x = array("\x7f"=>'', "\x80"=>'&#8364;', "\x81"=>'', "\x83"=>'&#402;', "\x85"=>'&#8230;', "\x86"=>'&#8224;', "\x87"=>'&#8225;', "\x88"=>'&#710;', "\x89"=>'&#8240;', "\x8a"=>'&#352;', "\x8b"=>'&#8249;', "\x8c"=>'&#338;', "\x8d"=>'', "\x8e"=>'&#381;', "\x8f"=>'', "\x90"=>'', "\x95"=>'&#8226;', "\x96"=>'&#8211;', "\x97"=>'&#8212;', "\x98"=>'&#732;', "\x99"=>'&#8482;', "\x9a"=>'&#353;', "\x9b"=>'&#8250;', "\x9c"=>'&#339;', "\x9d"=>'', "\x9e"=>'&#382;', "\x9f"=>'&#376;');
@@ -195,9 +195,9 @@ class Htmlawed {
                 : array("\x82"=>'\'', "\x84"=>'"', "\x91"=>'\'', "\x92"=>'\'', "\x93"=>'"', "\x94"=>'"'));
         $t = strtr($t, $x);
       }
-  
+
       // Handle CDATA, comments, and entities.
-  
+
       if ($C['cdata'] || $C['comment']) {
         $t = preg_replace_callback('`<!(?:(?:--.*?--)|(?:\[CDATA\[.*?\]\]))>`sm', 'DataTables\HtmLawed\Htmlawed::hl_commentCdata', $t);
       }
@@ -209,22 +209,22 @@ class Htmlawed {
       if ($C['unique_ids'] && !isset($GLOBALS['hl_Ids'])) {
         $GLOBALS['hl_Ids'] = array();
       }
-  
+
       if ($C['hook']) {
         $t = call_user_func($C['hook'], $t, $C, $S);
       }
-  
+
       // Handle remaining text.
-  
+
       $t = preg_replace_callback('`<(?:(?:\s|$)|(?:[^>]*(?:>|$)))|>`m', 'DataTables\HtmLawed\Htmlawed::hl_tag', $t);
       $t = $C['balance'] ? self::hl_balance($t, $C['keep_bad'], $C['parent']) : $t;
       $t = (($C['cdata'] || $C['comment']) && strpos($t, "\x01") !== false)
            ? str_replace(array("\x01", "\x02", "\x03", "\x04", "\x05"), array('', '', '&', '<', '>'), $t)
            : $t;
       $t = $C['tidy'] ? self::hl_tidy($t, $C['tidy'], $C['parent']) : $t;
-  
+
       // Cleanup.
-  
+
       if ($C['show_setting'] && preg_match('`^[a-z][a-z0-9_]*$`i', $C['show_setting'])) {
         $GLOBALS[$C['show_setting']] = array('config'=>$C, 'spec'=>$S, 'time'=>microtime(true), 'version'=>self::hl_version());
       }
@@ -237,7 +237,7 @@ class Htmlawed {
       }
       return $t;
     }
-  
+
     /**
      * Validate attribute value and possibly reset to a default.
      *
@@ -306,7 +306,7 @@ class Htmlawed {
       $out = implode($valSep == ',' ? ', ' : ' ', $out);
       return (isset($out[0]) ? $out : (isset($ruleAr['default']) ? $ruleAr['default'] : 0));
     }
-  
+
     /*
      * Enforce parent-child validity of elements and balance tags.
      *
@@ -319,25 +319,25 @@ class Htmlawed {
     public static function hl_balance($t, $act=1, $parentEle='div')
     {
       // Group elements in different ways.
-  
+
       $closingTagOmitableEleAr = array('caption'=>1, 'colgroup'=>1, 'dd'=>1, 'dt'=>1, 'li'=>1, 'optgroup'=>1, 'option'=>1, 'p'=>1, 'rp'=>1, 'rt'=>1, 'tbody'=>1, 'td'=>1, 'tfoot'=>1, 'th'=>1, 'thead'=>1, 'tr'=>1);
-  
+
       // -- Block, inline, etc.
-  
+
       $blockEleAr = array('a'=>1, 'address'=>1, 'article'=>1, 'aside'=>1, 'blockquote'=>1, 'center'=>1, 'del'=>1, 'details'=>1, 'dialog'=>1, 'dir'=>1, 'dl'=>1, 'div'=>1, 'fieldset'=>1, 'figure'=>1, 'footer'=>1, 'form'=>1, 'ins'=>1, 'h1'=>1, 'h2'=>1, 'h3'=>1, 'h4'=>1, 'h5'=>1, 'h6'=>1, 'header'=>1, 'hr'=>1, 'isindex'=>1, 'main'=>1, 'menu'=>1, 'nav'=>1, 'noscript'=>1, 'ol'=>1, 'p'=>1, 'pre'=>1, 'section'=>1, 'slot'=>1, 'style'=>1, 'table'=>1, 'template'=>1, 'ul'=>1);
       $inlineEleAr = array('#pcdata'=>1, 'a'=>1, 'abbr'=>1, 'acronym'=>1, 'applet'=>1, 'audio'=>1, 'b'=>1, 'bdi'=>1, 'bdo'=>1, 'big'=>1, 'br'=>1, 'button'=>1, 'canvas'=>1, 'cite'=>1, 'code'=>1, 'command'=>1, 'data'=>1, 'datalist'=>1, 'del'=>1, 'dfn'=>1, 'em'=>1, 'embed'=>1, 'figcaption'=>1, 'font'=>1, 'i'=>1, 'iframe'=>1, 'img'=>1, 'input'=>1, 'ins'=>1, 'kbd'=>1, 'label'=>1, 'link'=>1, 'map'=>1, 'mark'=>1, 'meta'=>1, 'meter'=>1, 'object'=>1, 'output'=>1, 'picture'=>1, 'progress'=>1, 'q'=>1, 'ruby'=>1, 's'=>1, 'samp'=>1, 'select'=>1, 'script'=>1, 'small'=>1, 'span'=>1, 'strike'=>1, 'strong'=>1, 'sub'=>1, 'summary'=>1, 'sup'=>1, 'textarea'=>1, 'time'=>1, 'tt'=>1, 'u'=>1, 'var'=>1, 'video'=>1, 'wbr'=>1);
       $otherEleAr = array('area'=>1, 'caption'=>1, 'col'=>1, 'colgroup'=>1, 'command'=>1, 'dd'=>1, 'dt'=>1, 'hgroup'=>1, 'keygen'=>1, 'legend'=>1, 'li'=>1, 'optgroup'=>1, 'option'=>1, 'param'=>1, 'rb'=>1, 'rbc'=>1, 'rp'=>1, 'rt'=>1, 'rtc'=>1, 'script'=>1, 'source'=>1, 'tbody'=>1, 'td'=>1, 'tfoot'=>1, 'thead'=>1, 'th'=>1, 'tr'=>1, 'track'=>1);
       $flowEleAr = $blockEleAr + $inlineEleAr;
-  
+
       // -- Type of child allowed.
-  
+
       $blockKidEleAr = array('blockquote'=>1, 'form'=>1, 'map'=>1, 'noscript'=>1);
       $flowKidEleAr = array('a'=>1, 'article'=>1, 'aside'=>1, 'audio'=>1, 'button'=>1, 'canvas'=>1, 'del'=>1, 'details'=>1, 'dialog'=>1, 'div'=>1, 'dd'=>1, 'fieldset'=>1, 'figure'=>1, 'footer'=>1, 'header'=>1, 'iframe'=>1, 'ins'=>1, 'li'=>1, 'main'=>1, 'menu'=>1, 'nav'=>1, 'noscript'=>1, 'object'=>1, 'section'=>1, 'slot'=>1, 'style'=>1, 'td'=>1, 'template'=>1, 'th'=>1, 'video'=>1); // Later context-wise dynamic move of ins & del to $inlineKidEleAr
       $inlineKidEleAr = array('abbr'=>1, 'acronym'=>1, 'address'=>1, 'b'=>1, 'bdi'=>1, 'bdo'=>1, 'big'=>1, 'caption'=>1, 'cite'=>1, 'code'=>1, 'data'=>1, 'datalist'=>1, 'dfn'=>1, 'dt'=>1, 'em'=>1, 'figcaption'=>1, 'font'=>1, 'h1'=>1, 'h2'=>1, 'h3'=>1, 'h4'=>1, 'h5'=>1, 'h6'=>1, 'hgroup'=>1, 'i'=>1, 'kbd'=>1, 'label'=>1, 'legend'=>1, 'mark'=>1, 'meter'=>1, 'output'=>1, 'p'=>1, 'picture'=>1, 'pre'=>1, 'progress'=>1, 'q'=>1, 'rb'=>1, 'rt'=>1, 's'=>1, 'samp'=>1, 'small'=>1, 'span'=>1, 'strike'=>1, 'strong'=>1, 'sub'=>1, 'summary'=>1, 'sup'=>1, 'time'=>1, 'tt'=>1, 'u'=>1, 'var'=>1);
       $noKidEleAr = array('area'=>1, 'br'=>1, 'col'=>1, 'command'=>1, 'embed'=>1, 'hr'=>1, 'img'=>1, 'input'=>1, 'isindex'=>1, 'keygen'=>1, 'link'=>1, 'meta'=>1, 'param'=>1, 'source'=>1, 'track'=>1, 'wbr'=>1);
-  
+
       // Special parent-child relations.
-  
+
       $invalidMomKidAr = array('a'=>array('a'=>1, 'address'=>1, 'button'=>1, 'details'=>1, 'embed'=>1, 'iframe'=>1, 'keygen'=>1, 'label'=>1, 'select'=>1, 'textarea'=>1), 'address'=>array('address'=>1, 'article'=>1, 'aside'=>1, 'footer'=>1, 'h1'=>1, 'h2'=>1, 'h3'=>1, 'h4'=>1, 'h5'=>1, 'h6'=>1, 'header'=>1, 'hgroup'=>1, 'keygen'=>1, 'nav'=>1, 'section'=>1), 'audio'=>array('audio'=>1, 'video'=>1), 'button'=>array('a'=>1, 'address'=>1, 'button'=>1, 'details'=>1, 'embed'=>1, 'iframe'=>1, 'keygen'=>1, 'label'=>1, 'select'=>1, 'textarea'=>1), 'dfn'=>array('dfn'=>1), 'fieldset'=>array('fieldset'=>1), 'footer'=>array('footer'=>1, 'header'=>1), 'form'=>array('form'=>1), 'header'=>array('footer'=>1, 'header'=>1), 'label'=>array('label'=>1), 'main'=>array('main'=>1), 'meter'=>array('meter'=>1), 'noscript'=>array('script'=>1), 'progress'=>array('progress'=>1), 'rb'=>array('ruby'=>1), 'rt'=>array('ruby'=>1), 'time'=>array('time'=>1), 'video'=>array('audio'=>1, 'video'=>1));
       $invalidKidEleAr = array('a'=>1, 'address'=>1, 'article'=>1, 'aside'=>1, 'audio'=>1, 'button'=>1, 'details'=>1, 'dfn'=>1, 'embed'=>1, 'fieldset'=>1, 'footer'=>1, 'form'=>1, 'h1'=>1, 'h2'=>1, 'h3'=>1, 'h4'=>1, 'h5'=>1, 'h6'=>1, 'header'=>1, 'hgroup'=>1, 'iframe'=>1, 'keygen'=>1, 'label'=>1, 'main'=>1, 'meter'=>1, 'nav'=>1, 'progress'=>1, 'ruby'=>1, 'script'=>1, 'section'=>1, 'select'=>1, 'textarea'=>1, 'time'=>1, 'video'=>1); // $invalidMomKidAr values
       $invalidMomEleAr = array_keys($invalidMomKidAr);
@@ -346,9 +346,9 @@ class Htmlawed {
         $validMomKidAr['ol'] = $validMomKidAr['ul'] = $validMomKidAr['menu'] += array('menu'=>1, 'ol'=>1, 'ul'=>1);
       }
       $otherValidMomKidAr = array('address'=>array('p'=>1), 'applet'=>array('param'=>1), 'audio'=>array('source'=>1, 'track'=>1), 'blockquote'=>array('script'=>1), 'details'=>array('summary'=>1), 'fieldset'=>array('legend'=>1, '#pcdata'=>1),  'figure'=>array('figcaption'=>1),'form'=>array('script'=>1), 'map'=>array('area'=>1), 'legend'=>array('h1'=>1, 'h2'=>1, 'h3'=>1, 'h4'=>1, 'h5'=>1, 'h6'=>1), 'object'=>array('param'=>1, 'embed'=>1), 'summary'=>array('h1'=>1, 'h2'=>1, 'h3'=>1, 'h4'=>1, 'h5'=>1, 'h6'=>1, 'hgroup'=>1), 'video'=>array('source'=>1, 'track'=>1));
-  
+
       // Valid elements for top-level parent.
-  
+
       $mom = ((isset($flowEleAr[$parentEle]) && $parentEle != '#pcdata')
               || isset($otherEleAr[$parentEle]))
              ? $parentEle
@@ -378,16 +378,16 @@ class Htmlawed {
       if (strpos($mom, '-')) { // Custom element
         $validInMomEleAr = array('*' => 1, '#pcdata' =>1);
       }
-  
+
       // Loop over elements.
-  
+
       $t = explode('<', $t);
       $validKidsOfMom = $openEleQueue = array(); // Queue of opened elements
       ob_start();
       for ($i=-1, $eleCount=count($t); ++$i<$eleCount;) {
-  
+
         // Check element validity as child. Same code as section: Finishing (below).
-  
+
         if ($queueLength = count($openEleQueue)) {
           $eleNow = array_pop($openEleQueue);
           $openEleQueue[] = $eleNow;
@@ -449,9 +449,9 @@ class Htmlawed {
             echo preg_replace('`\S`', '', $content);
           }
         } // End: Check element validity as child
-  
+
         // Get parts of element.
-  
+
         if (!preg_match('`^(/?)([a-z][^ >]*)([^>]*)>(.*)`sm', $t[$i], $m)) {
           $content = $t[$i];
           continue;
@@ -461,9 +461,9 @@ class Htmlawed {
         $attrs = null; // Attribute string
         $content = null; // Content
         list($all, $slash, $ele, $attrs, $content) = $m;
-  
+
          // Handle closing tag.
-  
+
         if ($slash) {
           if (isset($noKidEleAr[$ele]) || !in_array($ele, $openEleQueue)) { // Element empty type or unopened
             continue;
@@ -486,9 +486,9 @@ class Htmlawed {
           unset($ele);
           continue;
         }
-  
+
         // Handle opening tag.
-  
+
         if (isset($blockKidEleAr[$ele]) && strlen(trim($content))) { // $blockKidEleAr element needs $blockEleAr element
           $t[$i] = "{$ele}{$attrs}>";
           array_splice($t, $i+1, 0, 'div>'. $content);
@@ -577,9 +577,9 @@ class Htmlawed {
         unset($ele);
         continue;
       } // End of For: loop over elements
-  
+
       // Finishing. Same code as: 'Check element validity as child'.
-  
+
       if ($queueLength = count($openEleQueue)) {
         $eleNow = array_pop($openEleQueue);
         $openEleQueue[] = $eleNow;
@@ -642,7 +642,7 @@ class Htmlawed {
           echo preg_replace('`\S`', '', $content);
         }
       } // End: Finishing
-  
+
       while (!empty($openEleQueue) && ($ele = array_pop($openEleQueue))) {
         echo '</', $ele, '>';
       }
@@ -650,7 +650,7 @@ class Htmlawed {
       ob_end_clean();
       return $o;
     }
-  
+
     /**
      * Handle comment/CDATA section.
      *
@@ -683,7 +683,7 @@ class Htmlawed {
           array("\x03", "\x04", "\x05"),
           ($type == 'comment' ? "\x01\x02\x04!--$t--\x05\x02\x01" : "\x01\x01\x04$t\x05\x01\x01"));
     }
-  
+
     /**
      * Transform deprecated element, with any attribute, into a new element.
      *
@@ -747,7 +747,7 @@ class Htmlawed {
       }
       return '';
     }
-  
+
     /**
      * Handle entity.
      *
@@ -807,7 +807,7 @@ class Htmlawed {
            : 'x'. dechex($n))
         . ';';
     }
-  
+
     /**
      * Check regex pattern for PHP error.
      *
@@ -848,7 +848,7 @@ class Htmlawed {
       }
       return $out;
     }
-  
+
     /**
      * Parse $spec htmLawed argument as array.
      *
@@ -858,9 +858,9 @@ class Htmlawed {
     public static function hl_spec($t)
     {
       $out  = array();
-  
+
       // Hide special characters used for rules.
-  
+
       if (!function_exists('hl_aux1')) {
         function hl_aux1($x) {
           return
@@ -877,9 +877,9 @@ class Htmlawed {
           array("\t", "\r", "\n", ' '),
           '',
           preg_replace_callback('/"(?>(`.|[^"])*)"/sm', 'hl_aux1', trim($t)));
-  
+
       // Tag, attribute, and rule separators: semi-colon, comma, and slash respectively.
-  
+
       for ($i = count(($t = explode(';', $t))); --$i>=0;) {
         $ele = $t[$i];
         if (
@@ -929,7 +929,7 @@ class Htmlawed {
             unset($ruleAr[$attr]['nomatch']);
           }
         }
-  
+
         if (!count($ruleAr) && !count($denyAttrAr)) {
           continue;
         }
@@ -945,10 +945,10 @@ class Htmlawed {
           }
         }
       }
-  
+
       return $out;
     }
-  
+
     /**
      * Handle tag text with </> limiters, and attributes in opening tags.
      *
@@ -960,9 +960,9 @@ class Htmlawed {
     {
       $t = $t[0];
       global $C;
-  
+
       // Check if </> character not in tag.
-  
+
       if ($t == '< ') {
         return '&lt; ';
       }
@@ -972,9 +972,9 @@ class Htmlawed {
       if (!preg_match('`^<(/?)([a-zA-Z][^\s>]*)([^>]*?)\s?>$`m', $t, $m)) { // Get tag with element name and attributes
         return str_replace(array('<', '>'), array('&lt;', '&gt;'), $t);
       }
-  
+
       // Check if element not permitted. Custom element names have certain requirements.
-  
+
       $ele = strtolower($m[2]);
       static $invalidCustomEleAr = array('annotation-xml'=>1, 'color-profile'=>1, 'font-face'=>1, 'font-face-src'=>1, 'font-face-uri'=>1, 'font-face-format'=>1, 'font-face-name'=>1, 'missing-glyph'=>1);
       if (
@@ -993,13 +993,13 @@ class Htmlawed {
          ) {
         return (($C['keep_bad']%2) ? str_replace(array('<', '>'), array('&lt;', '&gt;'), $t) : '');
       }
-  
+
       // Attribute string.
-  
+
       $attrStr = str_replace(array("\n", "\r", "\t"), ' ', trim($m[3]));
-  
+
       // Transform deprecated element.
-  
+
       static $deprecatedEleAr = array('acronym'=>1, 'applet'=>1, 'big'=>1, 'center'=>1, 'dir'=>1, 'font'=>1, 'isindex'=>1, 's'=>1, 'strike'=>1, 'tt'=>1);
       if ($C['make_tag_strict'] && isset($deprecatedEleAr[$ele])) {
         $eleTransformed = self::hl_deprecatedElement($ele, $attrStr, $C['make_tag_strict']); // hl_deprecatedElement uses referencing
@@ -1007,9 +1007,9 @@ class Htmlawed {
           return (($C['keep_bad'] % 2) ? str_replace(array('<', '>'), array('&lt;', '&gt;'), $t) : '');
         }
       }
-  
+
       // Handle closing tag.
-  
+
       static $emptyEleAr = array('area'=>1, 'br'=>1, 'col'=>1, 'command'=>1, 'embed'=>1, 'hr'=>1, 'img'=>1, 'input'=>1, 'isindex'=>1, 'keygen'=>1, 'link'=>1, 'meta'=>1, 'param'=>1, 'source'=>1, 'track'=>1, 'wbr'=>1);
       if (!empty($m[1])) {
         return(
@@ -1021,56 +1021,56 @@ class Htmlawed {
              ? str_replace(array('<', '>'), array('&lt;', '&gt;'), $t)
              : ''));
       }
-  
+
       // Handle opening tag.
-  
+
       // -- Sets of possible attributes.
-  
+
       // .. Element-specific non-global.
-  
+
       static $attrEleAr = array('abbr'=>array('td'=>1, 'th'=>1), 'accept'=>array('form'=>1, 'input'=>1), 'accept-charset'=>array('form'=>1), 'action'=>array('form'=>1), 'align'=>array('applet'=>1, 'caption'=>1, 'col'=>1, 'colgroup'=>1, 'div'=>1, 'embed'=>1, 'h1'=>1, 'h2'=>1, 'h3'=>1, 'h4'=>1, 'h5'=>1, 'h6'=>1, 'hr'=>1, 'iframe'=>1, 'img'=>1, 'input'=>1, 'legend'=>1, 'object'=>1, 'p'=>1, 'table'=>1, 'tbody'=>1, 'td'=>1, 'tfoot'=>1, 'th'=>1, 'thead'=>1, 'tr'=>1), 'allowfullscreen'=>array('iframe'=>1), 'alt'=>array('applet'=>1, 'area'=>1, 'img'=>1, 'input'=>1), 'archive'=>array('applet'=>1, 'object'=>1), 'async'=>array('script'=>1), 'autocomplete'=>array('form'=>1, 'input'=>1), 'autofocus'=>array('button'=>1, 'input'=>1, 'keygen'=>1, 'select'=>1, 'textarea'=>1), 'autoplay'=>array('audio'=>1, 'video'=>1), 'axis'=>array('td'=>1, 'th'=>1), 'bgcolor'=>array('embed'=>1, 'table'=>1, 'td'=>1, 'th'=>1, 'tr'=>1), 'border'=>array('img'=>1, 'object'=>1, 'table'=>1), 'bordercolor'=>array('table'=>1, 'td'=>1, 'tr'=>1), 'cellpadding'=>array('table'=>1), 'cellspacing'=>array('table'=>1), 'challenge'=>array('keygen'=>1), 'char'=>array('col'=>1, 'colgroup'=>1, 'tbody'=>1, 'td'=>1, 'tfoot'=>1, 'th'=>1, 'thead'=>1, 'tr'=>1), 'charoff'=>array('col'=>1, 'colgroup'=>1, 'tbody'=>1, 'td'=>1, 'tfoot'=>1, 'th'=>1, 'thead'=>1, 'tr'=>1), 'charset'=>array('a'=>1, 'script'=>1), 'checked'=>array('command'=>1, 'input'=>1), 'cite'=>array('blockquote'=>1, 'del'=>1, 'ins'=>1, 'q'=>1), 'classid'=>array('object'=>1), 'clear'=>array('br'=>1), 'code'=>array('applet'=>1), 'codebase'=>array('applet'=>1, 'object'=>1), 'codetype'=>array('object'=>1), 'color'=>array('font'=>1), 'cols'=>array('textarea'=>1), 'colspan'=>array('td'=>1, 'th'=>1), 'compact'=>array('dir'=>1, 'dl'=>1, 'menu'=>1, 'ol'=>1, 'ul'=>1), 'content'=>array('meta'=>1), 'controls'=>array('audio'=>1, 'video'=>1), 'coords'=>array('a'=>1, 'area'=>1), 'crossorigin'=>array('img'=>1), 'data'=>array('object'=>1), 'datetime'=>array('del'=>1, 'ins'=>1, 'time'=>1), 'declare'=>array('object'=>1), 'default'=>array('track'=>1), 'defer'=>array('script'=>1), 'dirname'=>array('input'=>1, 'textarea'=>1), 'disabled'=>array('button'=>1, 'command'=>1, 'fieldset'=>1, 'input'=>1, 'keygen'=>1, 'optgroup'=>1, 'option'=>1, 'select'=>1, 'textarea'=>1), 'download'=>array('a'=>1), 'enctype'=>array('form'=>1), 'face'=>array('font'=>1), 'flashvars'=>array('embed'=>1), 'for'=>array('label'=>1, 'output'=>1), 'form'=>array('button'=>1, 'fieldset'=>1, 'input'=>1, 'keygen'=>1, 'label'=>1, 'object'=>1, 'output'=>1, 'select'=>1, 'textarea'=>1), 'formaction'=>array('button'=>1, 'input'=>1), 'formenctype'=>array('button'=>1, 'input'=>1), 'formmethod'=>array('button'=>1, 'input'=>1), 'formnovalidate'=>array('button'=>1, 'input'=>1), 'formtarget'=>array('button'=>1, 'input'=>1), 'frame'=>array('table'=>1), 'frameborder'=>array('iframe'=>1), 'headers'=>array('td'=>1, 'th'=>1), 'height'=>array('applet'=>1, 'canvas'=>1, 'embed'=>1, 'iframe'=>1, 'img'=>1, 'input'=>1, 'object'=>1, 'td'=>1, 'th'=>1, 'video'=>1), 'high'=>array('meter'=>1), 'href'=>array('a'=>1, 'area'=>1, 'link'=>1), 'hreflang'=>array('a'=>1, 'area'=>1, 'link'=>1), 'hspace'=>array('applet'=>1, 'embed'=>1, 'img'=>1, 'object'=>1), 'icon'=>array('command'=>1), 'ismap'=>array('img'=>1, 'input'=>1), 'keyparams'=>array('keygen'=>1), 'keytype'=>array('keygen'=>1), 'kind'=>array('track'=>1), 'label'=>array('command'=>1, 'menu'=>1, 'option'=>1, 'optgroup'=>1, 'track'=>1), 'language'=>array('script'=>1), 'list'=>array('input'=>1), 'longdesc'=>array('img'=>1, 'iframe'=>1), 'loop'=>array('audio'=>1, 'video'=>1), 'low'=>array('meter'=>1), 'marginheight'=>array('iframe'=>1), 'marginwidth'=>array('iframe'=>1), 'max'=>array('input'=>1, 'meter'=>1, 'progress'=>1), 'maxlength'=>array('input'=>1, 'textarea'=>1), 'media'=>array('a'=>1, 'area'=>1, 'link'=>1, 'source'=>1, 'style'=>1), 'mediagroup'=>array('audio'=>1, 'video'=>1), 'method'=>array('form'=>1), 'min'=>array('input'=>1, 'meter'=>1), 'model'=>array('embed'=>1), 'multiple'=>array('input'=>1, 'select'=>1), 'muted'=>array('audio'=>1, 'video'=>1), 'name'=>array('a'=>1, 'applet'=>1, 'button'=>1, 'embed'=>1, 'fieldset'=>1, 'form'=>1, 'iframe'=>1, 'img'=>1, 'input'=>1, 'keygen'=>1, 'map'=>1, 'object'=>1, 'output'=>1, 'param'=>1, 'select'=>1, 'slot'=>1, 'textarea'=>1), 'nohref'=>array('area'=>1), 'noshade'=>array('hr'=>1), 'novalidate'=>array('form'=>1), 'nowrap'=>array('td'=>1, 'th'=>1), 'object'=>array('applet'=>1), 'open'=>array('details'=>1, 'dialog'=>1), 'optimum'=>array('meter'=>1), 'pattern'=>array('input'=>1), 'ping'=>array('a'=>1, 'area'=>1), 'placeholder'=>array('input'=>1, 'textarea'=>1), 'pluginspage'=>array('embed'=>1), 'pluginurl'=>array('embed'=>1), 'poster'=>array('video'=>1), 'pqg'=>array('keygen'=>1), 'preload'=>array('audio'=>1, 'video'=>1), 'prompt'=>array('isindex'=>1), 'pubdate'=>array('time'=>1), 'radiogroup'=>array('command'=>1), 'readonly'=>array('input'=>1, 'textarea'=>1), 'rel'=>array('a'=>1, 'area'=>1, 'link'=>1), 'required'=>array('input'=>1, 'select'=>1, 'textarea'=>1), 'rev'=>array('a'=>1), 'reversed'=>array('ol'=>1), 'rows'=>array('textarea'=>1), 'rowspan'=>array('td'=>1, 'th'=>1), 'rules'=>array('table'=>1), 'sandbox'=>array('iframe'=>1), 'scope'=>array('td'=>1, 'th'=>1), 'scoped'=>array('style'=>1), 'scrolling'=>array('iframe'=>1), 'seamless'=>array('iframe'=>1), 'selected'=>array('option'=>1), 'shape'=>array('a'=>1, 'area'=>1), 'size'=>array('font'=>1, 'hr'=>1, 'input'=>1, 'select'=>1), 'sizes'=>array('link'=>1), 'span'=>array('col'=>1, 'colgroup'=>1), 'src'=>array('audio'=>1, 'embed'=>1, 'iframe'=>1, 'img'=>1, 'input'=>1, 'script'=>1, 'source'=>1, 'track'=>1, 'video'=>1), 'srcdoc'=>array('iframe'=>1), 'srclang'=>array('track'=>1), 'srcset'=>array('img'=>1), 'standby'=>array('object'=>1), 'start'=>array('ol'=>1), 'step'=>array('input'=>1), 'summary'=>array('table'=>1), 'target'=>array('a'=>1, 'area'=>1, 'form'=>1), 'type'=>array('a'=>1, 'area'=>1, 'button'=>1, 'command'=>1, 'embed'=>1, 'input'=>1, 'li'=>1, 'link'=>1, 'menu'=>1, 'object'=>1, 'ol'=>1, 'param'=>1, 'script'=>1, 'source'=>1, 'style'=>1, 'ul'=>1), 'typemustmatch'=>array('object'=>1), 'usemap'=>array('img'=>1, 'input'=>1, 'object'=>1), 'valign'=>array('col'=>1, 'colgroup'=>1, 'tbody'=>1, 'td'=>1, 'tfoot'=>1, 'th'=>1, 'thead'=>1, 'tr'=>1), 'value'=>array('button'=>1, 'data'=>1, 'input'=>1, 'li'=>1, 'meter'=>1, 'option'=>1, 'param'=>1, 'progress'=>1), 'valuetype'=>array('param'=>1), 'vspace'=>array('applet'=>1, 'embed'=>1, 'img'=>1, 'object'=>1), 'width'=>array('applet'=>1, 'canvas'=>1, 'col'=>1, 'colgroup'=>1, 'embed'=>1, 'hr'=>1, 'iframe'=>1, 'img'=>1, 'input'=>1, 'object'=>1, 'pre'=>1, 'table'=>1, 'td'=>1, 'th'=>1, 'video'=>1), 'wmode'=>array('embed'=>1), 'wrap'=>array('textarea'=>1));
-  
+
       // .. Empty.
-  
+
       static $emptyAttrAr = array('allowfullscreen'=>1, 'checkbox'=>1, 'checked'=>1, 'command'=>1, 'compact'=>1, 'declare'=>1, 'defer'=>1, 'default'=>1, 'disabled'=>1, 'hidden'=>1, 'inert'=>1, 'ismap'=>1, 'itemscope'=>1, 'multiple'=>1, 'nohref'=>1, 'noresize'=>1, 'noshade'=>1, 'nowrap'=>1, 'open'=>1, 'radio'=>1, 'readonly'=>1, 'required'=>1, 'reversed'=>1, 'selected'=>1);
-  
+
       // .. Global.
-  
+
       static $globalAttrAr = array(
-  
+
          // .... General.
-  
+
         'accesskey'=>1, 'autocapitalize'=>1, 'autofocus'=>1, 'class'=>1, 'contenteditable'=>1, 'contextmenu'=>1, 'dir'=>1, 'draggable'=>1, 'dropzone'=>1, 'enterkeyhint'=>1, 'hidden'=>1, 'id'=>1, 'inert'=>1, 'inputmode'=>1, 'is'=>1, 'itemid'=>1, 'itemprop'=>1, 'itemref'=>1, 'itemscope'=>1, 'itemtype'=>1, 'lang'=>1, 'nonce'=>1, 'role'=>1, 'slot'=>1, 'spellcheck'=>1, 'style'=>1, 'tabindex'=>1, 'title'=>1, 'translate'=>1, 'xmlns'=>1, 'xml:base'=>1, 'xml:lang'=>1, 'xml:space'=>1,
-  
+
         // .... Event.
-  
+
         'onabort'=>1, 'onauxclick'=>1, 'onblur'=>1, 'oncancel'=>1, 'oncanplay'=>1, 'oncanplaythrough'=>1, 'onchange'=>1, 'onclick'=>1, 'onclose'=>1, 'oncontextlost'=>1, 'oncontextmenu'=>1, 'oncontextrestored'=>1, 'oncopy'=>1, 'oncuechange'=>1, 'oncut'=>1, 'ondblclick'=>1, 'ondrag'=>1, 'ondragend'=>1, 'ondragenter'=>1, 'ondragleave'=>1, 'ondragover'=>1, 'ondragstart'=>1, 'ondrop'=>1, 'ondurationchange'=>1, 'onemptied'=>1, 'onended'=>1, 'onerror'=>1, 'onfocus'=>1, 'onformchange'=>1, 'onformdata'=>1, 'onforminput'=>1, 'ongotpointercapture'=>1, 'oninput'=>1, 'oninvalid'=>1, 'onkeydown'=>1, 'onkeypress'=>1, 'onkeyup'=>1, 'onload'=>1, 'onloadeddata'=>1, 'onloadedmetadata'=>1, 'onloadend'=>1, 'onloadstart'=>1, 'onlostpointercapture'=>1, 'onmousedown'=>1, 'onmouseenter'=>1, 'onmouseleave'=>1, 'onmousemove'=>1, 'onmouseout'=>1, 'onmouseover'=>1, 'onmouseup'=>1, 'onmousewheel'=>1, 'onpaste'=>1, 'onpause'=>1, 'onplay'=>1, 'onplaying'=>1, 'onpointercancel'=>1, 'onpointerdown'=>1, 'onpointerenter'=>1, 'onpointerleave'=>1, 'onpointermove'=>1, 'onpointerout'=>1, 'onpointerover'=>1, 'onpointerup'=>1, 'onprogress'=>1, 'onratechange'=>1, 'onreadystatechange'=>1, 'onreset'=>1, 'onresize'=>1, 'onscroll'=>1, 'onsearch'=>1, 'onsecuritypolicyviolation'=>1, 'onseeked'=>1, 'onseeking'=>1, 'onselect'=>1, 'onshow'=>1, 'onslotchange'=>1, 'onstalled'=>1, 'onsubmit'=>1, 'onsuspend'=>1, 'ontimeupdate'=>1, 'ontoggle'=>1, 'ontouchcancel'=>1, 'ontouchend'=>1, 'ontouchmove'=>1, 'ontouchstart'=>1, 'onvolumechange'=>1, 'onwaiting'=>1, 'onwheel'=>1,
-  
+
         // .... Aria.
-  
+
         'aria-activedescendant'=>1, 'aria-atomic'=>1, 'aria-autocomplete'=>1, 'aria-braillelabel'=>1, 'aria-brailleroledescription'=>1, 'aria-busy'=>1, 'aria-checked'=>1, 'aria-colcount'=>1, 'aria-colindex'=>1, 'aria-colindextext'=>1, 'aria-colspan'=>1, 'aria-controls'=>1, 'aria-current'=>1, 'aria-describedby'=>1, 'aria-description'=>1, 'aria-details'=>1, 'aria-disabled'=>1, 'aria-dropeffect'=>1, 'aria-errormessage'=>1, 'aria-expanded'=>1, 'aria-flowto'=>1, 'aria-grabbed'=>1, 'aria-haspopup'=>1, 'aria-hidden'=>1, 'aria-invalid'=>1, 'aria-keyshortcuts'=>1, 'aria-label'=>1, 'aria-labelledby'=>1, 'aria-level'=>1, 'aria-live'=>1, 'aria-multiline'=>1, 'aria-multiselectable'=>1, 'aria-orientation'=>1, 'aria-owns'=>1, 'aria-placeholder'=>1, 'aria-posinset'=>1, 'aria-pressed'=>1, 'aria-readonly'=>1, 'aria-relevant'=>1, 'aria-required'=>1, 'aria-roledescription'=>1, 'aria-rowcount'=>1, 'aria-rowindex'=>1, 'aria-rowindextext'=>1, 'aria-rowspan'=>1, 'aria-selected'=>1, 'aria-setsize'=>1, 'aria-sort'=>1, 'aria-valuemax'=>1, 'aria-valuemin'=>1, 'aria-valuenow'=>1, 'aria-valuetext'=>1);
-  
+
       static $urlAttrAr = array('action'=>1, 'archive'=>1, 'cite'=>1, 'classid'=>1, 'codebase'=>1, 'data'=>1, 'href'=>1, 'itemtype'=>1, 'longdesc'=>1, 'model'=>1, 'pluginspage'=>1, 'pluginurl'=>1, 'poster'=>1, 'src'=>1, 'srcset'=>1, 'usemap'=>1); // Excludes style and on*
-  
+
       // .. Deprecated.
-  
+
       $alterDeprecAttr = 0;
       if ($C['no_deprecated_attr']) {
         static $deprecAttrEleAr = array('align'=>array('caption'=>1, 'div'=>1, 'h1'=>1, 'h2'=>1, 'h3'=>1, 'h4'=>1, 'h5'=>1, 'h6'=>1, 'hr'=>1, 'img'=>1, 'input'=>1, 'legend'=>1, 'object'=>1, 'p'=>1, 'table'=>1), 'bgcolor'=>array('table'=>1, 'td'=>1, 'th'=>1, 'tr'=>1), 'border'=>array('object'=>1), 'bordercolor'=>array('table'=>1, 'td'=>1, 'tr'=>1), 'cellspacing'=>array('table'=>1), 'clear'=>array('br'=>1), 'compact'=>array('dl'=>1, 'ol'=>1, 'ul'=>1), 'height'=>array('td'=>1, 'th'=>1), 'hspace'=>array('img'=>1, 'object'=>1), 'language'=>array('script'=>1), 'name'=>array('a'=>1, 'form'=>1, 'iframe'=>1, 'img'=>1, 'map'=>1), 'noshade'=>array('hr'=>1), 'nowrap'=>array('td'=>1, 'th'=>1), 'size'=>array('hr'=>1), 'vspace'=>array('img'=>1, 'object'=>1), 'width'=>array('hr'=>1, 'pre'=>1, 'table'=>1, 'td'=>1, 'th'=>1));
         static $deprecAttrPossibleEleAr = array('a'=>1, 'br'=>1, 'caption'=>1, 'div'=>1, 'dl'=>1, 'form'=>1, 'h1'=>1, 'h2'=>1, 'h3'=>1, 'h4'=>1, 'h5'=>1, 'h6'=>1, 'hr'=>1, 'iframe'=>1, 'img'=>1, 'input'=>1, 'legend'=>1, 'map'=>1, 'object'=>1, 'ol'=>1, 'p'=>1, 'pre'=>1, 'script'=>1, 'table'=>1, 'td'=>1, 'th'=>1, 'tr'=>1, 'ul'=>1);
         $alterDeprecAttr = isset($deprecAttrPossibleEleAr[$ele]) ? 1 : 0;
       }
-  
+
       // -- Standard attribute values that may need lowercasing.
-  
+
       if ($C['lc_std_val']) {
         static $lCaseStdAttrValAr = array('all'=>1, 'auto'=>1, 'baseline'=>1, 'bottom'=>1, 'button'=>1, 'captions'=>1, 'center'=>1, 'chapters'=>1, 'char'=>1, 'checkbox'=>1, 'circle'=>1, 'col'=>1, 'colgroup'=>1, 'color'=>1, 'cols'=>1, 'data'=>1, 'date'=>1, 'datetime'=>1, 'datetime-local'=>1, 'default'=>1, 'descriptions'=>1, 'email'=>1, 'file'=>1, 'get'=>1, 'groups'=>1, 'hidden'=>1, 'image'=>1, 'justify'=>1, 'left'=>1, 'ltr'=>1, 'metadata'=>1, 'middle'=>1, 'month'=>1, 'none'=>1, 'number'=>1, 'object'=>1, 'password'=>1, 'poly'=>1, 'post'=>1, 'preserve'=>1, 'radio'=>1, 'range'=>1, 'rect'=>1, 'ref'=>1, 'reset'=>1, 'right'=>1, 'row'=>1, 'rowgroup'=>1, 'rows'=>1, 'rtl'=>1, 'search'=>1, 'submit'=>1, 'subtitles'=>1, 'tel'=>1, 'text'=>1, 'time'=>1, 'top'=>1, 'url'=>1, 'week'=>1);
         static $lCaseStdAttrValPossibleEleAr = array('a'=>1, 'area'=>1, 'bdo'=>1, 'button'=>1, 'col'=>1, 'fieldset'=>1, 'form'=>1, 'img'=>1, 'input'=>1, 'object'=>1, 'ol'=>1, 'optgroup'=>1, 'option'=>1, 'param'=>1, 'script'=>1, 'select'=>1, 'table'=>1, 'td'=>1, 'textarea'=>1, 'tfoot'=>1, 'th'=>1, 'thead'=>1, 'tr'=>1, 'track'=>1, 'xml:space'=>1);
         $lCaseStdAttrVal = isset($lCaseStdAttrValPossibleEleAr[$ele]) ? 1 : 0;
       }
-  
+
       // -- Get attribute name-value pairs.
-  
+
       if (strpos($attrStr, "\x01") !== false) { // Remove CDATA/comment
         $attrStr = preg_replace('`\x01[^\x01]*\x01`', '', $attrStr);
       }
@@ -1117,55 +1117,55 @@ class Htmlawed {
       if ($state == 1) {
         $attrAr[$attr] = '';
       }
-  
+
       // -- Clean attributes.
-  
+
       global $S;
       $eleSpec = isset($S[$ele]) ? $S[$ele] : array();
       $filtAttrAr = array(); // Finalized attributes
       $deniedAttrAr = $C['deny_attribute'];
-  
+
       foreach ($attrAr as $attr=>$v) {
-  
+
         // .. Check if attribute is permitted.
-  
+
         if (
-  
+
            // .... Valid attribute.
-  
+
           ((isset($attrEleAr[$attr][$ele])
             || isset($globalAttrAr[$attr])
             || preg_match('`data-((?!xml)[^:]+$)`', $attr)
             || (strpos($ele, '-')
                 && strpos($attr, 'data-xml') !== 0))
-  
+
            // .... No denial through $spec.
-  
+
            && (empty($eleSpec)
                || (!isset($eleSpec['deny'])
                    || (!isset($eleSpec['deny']['*'])
                        && !isset($eleSpec['deny'][$attr])
                        && !isset($eleSpec['deny'][preg_replace('`^(on|aria|data).+`', '\\1', $attr). '*']))))
-  
+
            // .... No denial through $config.
-  
+
            && (empty($deniedAttrAr)
                || (isset($deniedAttrAr['*'])
                    ? (isset($deniedAttrAr["-$attr"])
                       || isset($deniedAttrAr['-'. preg_replace('`^(on|aria|data)..+`', '\\1', $attr). '*']))
                    : (!isset($deniedAttrAr[$attr])
                       && !isset($deniedAttrAr[preg_replace('`^(on|aria|data).+`', '\\1', $attr). '*'])))))
-  
+
           // .... Permit if permission through $spec.
-  
+
           || (!empty($eleSpec)
               && (isset($eleSpec[$attr])
                   || (isset($globalAttrAr[$attr])
                       && isset($eleSpec[preg_replace('`^(on|aria|data).+`', '\\1', $attr). '*']))))
           ) {
-  
+
           // .. Attribute with no value or standard value.
-  
+
           if (isset($emptyAttrAr[$attr])) {
             $v = $attr;
           } elseif (
@@ -1175,9 +1175,9 @@ class Htmlawed {
             ) {
             $v = (isset($lCaseStdAttrValAr[($vNew = strtolower($v))])) ? $vNew : $v;
           }
-  
+
           // .. URLs and CSS expressions in style attribute.
-  
+
           if ($attr == 'style' && !$C['style_pass']) {
             if (false !== strpos($v, '&#')) { // Change any entity to character
               static $entityAr = array('&#32;'=>' ', '&#x20;'=>' ', '&#58;'=>':', '&#x3a;'=>':', '&#34;'=>'"', '&#x22;'=>'"', '&#40;'=>'(', '&#x28;'=>'(', '&#41;'=>')', '&#x29;'=>')', '&#42;'=>'*', '&#x2a;'=>'*', '&#47;'=>'/', '&#x2f;'=>'/', '&#92;'=>'\\', '&#x5c;'=>'\\', '&#101;'=>'e', '&#69;'=>'e', '&#x45;'=>'e', '&#x65;'=>'e', '&#105;'=>'i', '&#73;'=>'i', '&#x49;'=>'i', '&#x69;'=>'i', '&#108;'=>'l', '&#76;'=>'l', '&#x4c;'=>'l', '&#x6c;'=>'l', '&#110;'=>'n', '&#78;'=>'n', '&#x4e;'=>'n', '&#x6e;'=>'n', '&#111;'=>'o', '&#79;'=>'o', '&#x4f;'=>'o', '&#x6f;'=>'o', '&#112;'=>'p', '&#80;'=>'p', '&#x50;'=>'p', '&#x70;'=>'p', '&#114;'=>'r', '&#82;'=>'r', '&#x52;'=>'r', '&#x72;'=>'r', '&#115;'=>'s', '&#83;'=>'s', '&#x53;'=>'s', '&#x73;'=>'s', '&#117;'=>'u', '&#85;'=>'u', '&#x55;'=>'u', '&#x75;'=>'u', '&#120;'=>'x', '&#88;'=>'x', '&#x58;'=>'x', '&#x78;'=>'x', '&#39;'=>"'", '&#x27;'=>"'");
@@ -1191,9 +1191,9 @@ class Htmlawed {
             $v = !$C['css_expression']
                  ? preg_replace('`expression`i', ' ', preg_replace('`\\\\\S|(/|(%2f))(\*|(%2a))`i', ' ', $v))
                  : $v;
-  
+
           // .. URLs in other attributes.
-  
+
           } elseif (isset($urlAttrAr[$attr]) || (isset($globalAttrAr[$attr]) && strpos($attr, 'on') === 0)) {
             $v =
               str_replace("­", ' ',
@@ -1223,9 +1223,9 @@ class Htmlawed {
             } else {
               $v = self::hl_url($v, $attr);
             }
-  
+
             // Anti-spam measure.
-  
+
             if ($attr == 'href') {
               if ($C['anti_mail_spam'] && strpos($v, 'mailto:') === 0) {
                 $v = str_replace('@', htmlspecialchars($C['anti_mail_spam']), $v);
@@ -1251,27 +1251,27 @@ class Htmlawed {
               }
             }
           }
-  
+
           // .. Check attribute value against any $spec rule.
-  
+
           if (isset($eleSpec[$attr])
               && is_array($eleSpec[$attr])
               && ($v = self::hl_attributeValue($attr, $v, $eleSpec[$attr], $ele)) === 0) {
             continue;
           }
-  
+
           $filtAttrAr[$attr] = str_replace('"', '&quot;', $v);
         }
       }
-  
+
       // -- Add nofollow.
-  
+
       if (isset($addNofollow)) {
         $filtAttrAr['rel'] = isset($filtAttrAr['rel']) ? $filtAttrAr['rel']. ' nofollow' : 'nofollow';
       }
-  
+
       // -- Add required attributes.
-  
+
       static $requiredAttrAr = array('area'=>array('alt'=>'area'), 'bdo'=>array('dir'=>'ltr'), 'command'=>array('label'=>''), 'form'=>array('action'=>''), 'img'=>array('src'=>'', 'alt'=>'image'), 'map'=>array('name'=>''), 'optgroup'=>array('label'=>''), 'param'=>array('name'=>''), 'style'=>array('scoped'=>''), 'textarea'=>array('rows'=>'10', 'cols'=>'50'));
       if (isset($requiredAttrAr[$ele])) {
         foreach ($requiredAttrAr[$ele] as $k=>$v) {
@@ -1280,9 +1280,9 @@ class Htmlawed {
           }
         }
       }
-  
+
       // -- Transform deprecated attributes into CSS declarations in style attribute.
-  
+
       if ($alterDeprecAttr) {
         $css = array();
         foreach ($filtAttrAr as $name=>$val) {
@@ -1360,9 +1360,9 @@ class Htmlawed {
             : $css. ';';
         }
       }
-  
+
       // -- Enforce unique id attribute values.
-  
+
       if ($C['unique_ids'] && isset($filtAttrAr['id'])) {
         if (preg_match('`\s`', ($id = $filtAttrAr['id'])) || (isset($GLOBALS['hl_Ids'][$id]) && $C['unique_ids'] == 1)) {
           unset($filtAttrAr['id']);
@@ -1373,27 +1373,27 @@ class Htmlawed {
           $GLOBALS['hl_Ids'][($filtAttrAr['id'] = $id)] = 1;
         }
       }
-  
+
       // -- Handle lang attributes.
-  
+
       if ($C['xml:lang'] && isset($filtAttrAr['lang'])) {
         $filtAttrAr['xml:lang'] = isset($filtAttrAr['xml:lang']) ? $filtAttrAr['xml:lang'] : $filtAttrAr['lang'];
         if ($C['xml:lang'] == 2) {
           unset($filtAttrAr['lang']);
         }
       }
-  
+
       // -- If transformed element, modify style attribute.
-  
+
       if (!empty($eleTransformed)) {
         $filtAttrAr['style'] =
           isset($filtAttrAr['style'])
           ? rtrim($filtAttrAr['style'], ' ;'). '; '. $eleTransformed
           : $eleTransformed;
       }
-  
+
       // -- Return opening tag with attributes.
-  
+
       if (empty($C['hook_tag'])) {
         $attrStr = '';
         foreach ($filtAttrAr as $k=>$v) {
@@ -1404,7 +1404,7 @@ class Htmlawed {
         return call_user_func($C['hook_tag'], $ele, $filtAttrAr);
       }
     }
-  
+
     /**
      * Tidy/beautify HTM by adding newline and other spaces (padding),
      * or compact by removing unnecessary spaces.
@@ -1419,9 +1419,9 @@ class Htmlawed {
       if (strpos(' pre,script,textarea', "$parentEle,")) {
         return $t;
       }
-  
+
       // Hide CDATA/comment.
-  
+
       if (!function_exists('hl_aux2')) {
         function hl_aux2($x) {
           return
@@ -1441,7 +1441,7 @@ class Htmlawed {
             array('`(<(!\[CDATA\[))(.+?)(\]\]>)`sm', '`(<(!--))(.+?)(-->)`sm', '`(<(pre|script|textarea)[^>]*?>)(.+?)(</\2>)`sm'),
             'hl_aux2',
             $t));
-  
+
       if (($format = strtolower($format)) == -1) {
         return
           str_replace(array("\x01", "\x02", "\x03", "\x04", "\x05", "\x07"), array('<', '>', "\n", "\r", "\t", ' '), $t);
@@ -1452,14 +1452,14 @@ class Htmlawed {
         ? str_repeat($padChar, intval($m[0]))
         : str_repeat($padChar, ($padChar == "\t" ? 1 : 2));
       $leadN = preg_match('`[ts]([1-9])`', $format, $m) ? intval($m[1]) : 0;
-  
+
       // Group elements by line-break requirement.
-  
+
       $postCloseEleAr = array('br'=>1); // After closing
       $preEleAr = array('button'=>1, 'command'=>1, 'input'=>1, 'option'=>1, 'param'=>1, 'track'=>1); // Before opening or closing
       $preOpenPostCloseEleAr = array('audio'=>1, 'canvas'=>1, 'caption'=>1, 'dd'=>1, 'dt'=>1, 'figcaption'=>1, 'h1'=>1, 'h2'=>1, 'h3'=>1, 'h4'=>1, 'h5'=>1, 'h6'=>1, 'isindex'=>1, 'label'=>1, 'legend'=>1, 'li'=>1, 'object'=>1, 'p'=>1, 'pre'=>1, 'style'=>1, 'summary'=>1, 'td'=>1, 'textarea'=>1, 'th'=>1, 'video'=>1); // Before opening and after closing
       $prePostEleAr = array('address'=>1, 'article'=>1, 'aside'=>1, 'blockquote'=>1, 'center'=>1, 'colgroup'=>1, 'datalist'=>1, 'details'=>1, 'dialog'=>1, 'dir'=>1, 'div'=>1, 'dl'=>1, 'fieldset'=>1, 'figure'=>1, 'footer'=>1, 'form'=>1, 'header'=>1, 'hgroup'=>1, 'hr'=>1, 'iframe'=>1, 'main'=>1, 'map'=>1, 'menu'=>1, 'nav'=>1, 'noscript'=>1, 'ol'=>1, 'optgroup'=>1, 'picture'=>1, 'rbc'=>1, 'rtc'=>1, 'ruby'=>1, 'script'=>1, 'section'=>1, 'select'=>1, 'table'=>1, 'tbody'=>1, 'template'=>1, 'tfoot'=>1, 'thead'=>1, 'tr'=>1, 'ul'=>1); // Before and after opening and closing
-  
+
       $doPad = 1;
       $t = explode('<', $t);
       while ($doPad) {
@@ -1517,7 +1517,7 @@ class Htmlawed {
       }
       return str_replace(array("\x01", "\x02", "\x03", "\x04", "\x05", "\x07"), array('<', '>', "\n", "\r", "\t", ' '), $t);
     }
-  
+
     /**
      * Handle URL to convert to relative/absolute type,
      * block scheme, or add anti-spam text.
@@ -1574,7 +1574,7 @@ class Htmlawed {
       }
       return "{$preUrl}{$url}{$postUrl}";
     }
-  
+
     /**
      * Report version.
      *

--- a/composer.php
+++ b/composer.php
@@ -4,7 +4,7 @@
  * to define a parameter that allows the Editor PHP libraries to load
  * (they check for this parameter and will exit immediately if not
  * defined for security).
- * 
+ *
  * This file should NOT be included manually. It is for use by
  * composer only.
  */

--- a/config.php
+++ b/config.php
@@ -21,10 +21,9 @@ $sql_details = array(
 
 
 // This is included for the development and deploy environment used on the DataTables
-// server. You can delete this block - it just includes my own user/pass without making 
+// server. You can delete this block - it just includes my own user/pass without making
 // them public!
 if ( is_file($_SERVER['DOCUMENT_ROOT']."/datatables/pdo.php") ) {
 	include( $_SERVER['DOCUMENT_ROOT']."/datatables/pdo.php" );
 }
 // /End development include
-


### PR DESCRIPTION
extracted from #17, non functional change

done by:
```
foreach ($files as $f) {
    $d = file_get_contents($f);

    $d = preg_replace("~ +(?=$|\n)~", "", $d);
    $d = trim($d);
    $d .= "\n";

    file_put_contents($f, $d);
}
```
and reviewed manually