### PR TITLE
Update Bootstrap.php

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -13,8 +13,9 @@
 
 namespace DataTables;
 
-// Ensure Editor is loadable.
-if (!defined('DATATABLES') && !class_exists('\DataTables\Editor')) {
+// ensure included from DataTables.php
+// this file must not be included when installed using composer
+if (!defined('DATATABLES')) {
 	exit(1);
 }
 

--- a/config.php
+++ b/config.php
@@ -1,7 +1,8 @@
 <?php
 
-// Ensure Editor is loadable.
-if (!class_exists('\DataTables\Editor')) {
+// ensure DataTables.php was included
+// this file must not be included when installed using composer
+if (!defined('DATATABLES')) {
 	exit(1);
 }
 


### PR DESCRIPTION
based on https://github.com/DataTables/Editor-PHP/pull/13#issuecomment-1630511373 discussion

If I understand the loading correctly:

- Without composer, `DataTables.php` is included by the developer. Here the `DATATABLES` constant is defined.
- With composer, these files are never included. Even not the config one, as vendored files should never be edit directly.