### PR TITLE
Simplify "ïs_callable && is_object" to "instanceof Closure"

### DIFF
--- a/Database/Query.php
+++ b/Database/Query.php
@@ -637,7 +637,7 @@ abstract class Query
 	{
 		if ($key === null) {
 			return $this;
-		} elseif (is_callable($key) && is_object($key)) { // is a closure
+		} elseif ($key instanceof \Closure) {
 			$this->_where_group(true, 'AND');
 			$key($this);
 			$this->_where_group(false, 'OR');
@@ -698,7 +698,7 @@ abstract class Query
 	{
 		if ($key === null) {
 			return $this;
-		} elseif (is_callable($key) && is_object($key)) {
+		} elseif ($key instanceof \Closure) {
 			$this->_where_group(true, 'OR');
 			$key($this);
 			$this->_where_group(false, 'OR');
@@ -743,7 +743,7 @@ abstract class Query
 	 */
 	public function where_group($inOut, $op = 'AND')
 	{
-		if (is_callable($inOut) && is_object($inOut)) {
+		if ($inOut instanceof \Closure) {
 			$this->_where_group(true, $op);
 			$inOut($this);
 			$this->_where_group(false, $op);

--- a/Editor.php
+++ b/Editor.php
@@ -953,8 +953,6 @@ class Editor extends Ext
 	 * Process a request from the Editor client-side to get / set data.
 	 *
 	 * @param array $data Data to process
-	 *
-	 * @private
 	 */
 	private function _process($data)
 	{
@@ -1085,8 +1083,6 @@ class Editor extends Ext
 	 *                         server-side processing requests from DataTables).
 	 *
 	 * @return array DataTables get information
-	 *
-	 * @private
 	 */
 	private function _get($id = null, $http = null)
 	{
@@ -1226,8 +1222,6 @@ class Editor extends Ext
 
 	/**
 	 * Insert a new row in the database.
-	 *
-	 *  @private
 	 */
 	private function _insert($values)
 	{
@@ -1285,8 +1279,6 @@ class Editor extends Ext
 	 * @param string $id The DOM ID for the row that is being edited.
 	 *
 	 * @return array Row's data
-	 *
-	 * @private
 	 */
 	private function _update($id, $values)
 	{
@@ -1322,8 +1314,6 @@ class Editor extends Ext
 
 	/**
 	 * Delete one or more rows from the database.
-	 *
-	 *  @private
 	 */
 	private function _remove($data)
 	{
@@ -1395,8 +1385,6 @@ class Editor extends Ext
 	 * File upload.
 	 *
 	 * @param array $data Upload data
-	 *
-	 * @private
 	 */
 	private function _upload($data)
 	{
@@ -1466,8 +1454,6 @@ class Editor extends Ext
 	 * @param number[] $ids        Limit to a specific set of ids
 	 *
 	 * @return array File information
-	 *
-	 * @private
 	 */
 	private function _fileData($limitTable = null, $ids = null, $data = null)
 	{
@@ -1503,8 +1489,6 @@ class Editor extends Ext
 	 * @param Field[] $fields     Fields to get file information about
 	 * @param string  $limitTable Limit the data gathering to a single table
 	 *                            only
-	 *
-	 * @private
 	 */
 	private function _fileDataFields(&$files, $fields, $limitTable, $idsIn = null, $data = null)
 	{
@@ -1563,8 +1547,6 @@ class Editor extends Ext
 
 	/**
 	 * Run the file clean up.
-	 *
-	 * @private
 	 */
 	private function _fileClean()
 	{
@@ -1599,8 +1581,6 @@ class Editor extends Ext
 	 * @param array                      $http  Parameters from HTTP request
 	 *
 	 * @return array Server-side processing information array
-	 *
-	 * @private
 	 */
 	private function _ssp_query($query, $http)
 	{
@@ -1674,8 +1654,6 @@ class Editor extends Ext
 	 *
 	 * @param \DataTables\Database\Query $query Query instance to apply sorting to
 	 * @param array                      $http  HTTP variables (i.e. GET or POST)
-	 *
-	 * @private
 	 */
 	private function _ssp_sort($query, $http)
 	{
@@ -1921,8 +1899,6 @@ class Editor extends Ext
 	 *
 	 * @param \DataTables\Database\Query $query Query instance to apply the WHERE conditions to
 	 * @param array                      $http  HTTP variables (i.e. GET or POST)
-	 *
-	 * @private
 	 */
 	private function _ssp_filter($query, $http)
 	{
@@ -2052,8 +2028,6 @@ class Editor extends Ext
 	 *
 	 * @param \DataTables\Database\Query $query Query instance to apply the offset / limit to
 	 * @param array                      $http  HTTP variables (i.e. GET or POST)
-	 *
-	 * @private
 	 */
 	private function _ssp_limit($query, $http)
 	{
@@ -2072,8 +2046,6 @@ class Editor extends Ext
 	 * Add local WHERE condition to query.
 	 *
 	 * @param \DataTables\Database\Query $query Query instance to apply the WHERE conditions to
-	 *
-	 * @private
 	 */
 	private function _get_where($query)
 	{
@@ -2097,8 +2069,6 @@ class Editor extends Ext
 	 * @param string $type Matching name type
 	 *
 	 * @return Field Field instance
-	 *
-	 * @private
 	 */
 	private function _find_field($name, $type)
 	{
@@ -2126,8 +2096,6 @@ class Editor extends Ext
 	 *
 	 * @return \DataTables\Database\Result Result from the query or null if no
 	 *                                     query performed.
-	 *
-	 * @private
 	 */
 	private function _insert_or_update($id, $values)
 	{
@@ -2214,8 +2182,6 @@ class Editor extends Ext
 	 *
 	 * @return \DataTables\Database\Result Result from the query or null if no query
 	 *                                     performed.
-	 *
-	 * @private
 	 */
 	private function _insert_or_update_table($table, $values, $where = null)
 	{
@@ -2304,8 +2270,6 @@ class Editor extends Ext
 	 * @param string $pkey  Database column name to match the ids on for the
 	 *                      delete condition. If not given the instance's base primary key is
 	 *                      used.
-	 *
-	 * @private
 	 */
 	private function _remove_table($table, $ids, $pkey = null)
 	{
@@ -2376,8 +2340,6 @@ class Editor extends Ext
 	 * Check the validity of the set options if  we are doing a join, since
 	 * there are some conditions for this state. Will throw an error if not
 	 * valid.
-	 *
-	 *  @private
 	 */
 	private function _prepJoin()
 	{
@@ -2418,8 +2380,6 @@ class Editor extends Ext
 	 * @param string $type Which part to get: `alias` (default) or `orig`.
 	 *
 	 * @returns string Alias
-	 *
-	 * @private
 	 */
 	private function _alias($name, $type = 'alias')
 	{
@@ -2451,8 +2411,6 @@ class Editor extends Ext
 	 *                     `column`
 	 *
 	 * @return string Part name
-	 *
-	 * @private
 	 */
 	private function _part($name, $type = 'table')
 	{
@@ -2486,8 +2444,6 @@ class Editor extends Ext
 
 	/**
 	 * Trigger an event.
-	 *
-	 * @private
 	 */
 	private function _trigger($eventName, &$arg1 = null, &$arg2 = null, &$arg3 = null, &$arg4 = null, &$arg5 = null)
 	{

--- a/Editor.php
+++ b/Editor.php
@@ -86,9 +86,9 @@ class Editor extends Ext
 	 *                     an Editor payload
 	 * @param string $name The parameter name that the action should be read from.
 	 *
-	 * @return string `Editor::ACTION_READ`, `Editor::ACTION_CREATE`,
-	 *                `Editor::ACTION_EDIT` or `Editor::ACTION_DELETE` indicating the request
-	 *                type.
+	 * @return static::ACTION_* `Editor::ACTION_READ`, `Editor::ACTION_CREATE`,
+	 *                          `Editor::ACTION_EDIT` or `Editor::ACTION_DELETE` indicating the request
+	 *                          type.
 	 */
 	public static function action($http, $name = 'action')
 	{
@@ -189,7 +189,7 @@ class Editor extends Ext
 	/** @var array */
 	private $_out = array();
 
-	/** @var array */
+	/** @var array[] */
 	private $_events = array();
 
 	/** @var bool */
@@ -201,7 +201,7 @@ class Editor extends Ext
 	/** @var string Log output path */
 	private $_debugLog = '';
 
-	/** @var callable */
+	/** @var array */
 	private $_validator = array();
 
 	/** @var bool Enable true / catch when processing */

--- a/Editor.php
+++ b/Editor.php
@@ -910,7 +910,7 @@ class Editor extends Ext
 			return $this->_where;
 		}
 
-		if (is_callable($key) && is_object($key)) {
+		if ($key instanceof \Closure) {
 			$this->_where[] = $key;
 		} else {
 			$this->_where[] = array(

--- a/Editor.php
+++ b/Editor.php
@@ -1628,7 +1628,7 @@ class Editor extends Ext
 	 * @param array $http  HTTP variables (i.e. GET or POST)
 	 * @param int   $index Index in the DataTables' submitted data
 	 *
-	 * @returns string DB field name
+	 * @return string DB field name
 	 *
 	 * @private Note that it is actually public for PHP 5.3 - thread 39810
 	 */
@@ -2379,7 +2379,7 @@ class Editor extends Ext
 	 * @param string $name SQL field
 	 * @param string $type Which part to get: `alias` (default) or `orig`.
 	 *
-	 * @returns string Alias
+	 * @return string Alias
 	 */
 	private function _alias($name, $type = 'alias')
 	{

--- a/Editor/Field.php
+++ b/Editor/Field.php
@@ -150,7 +150,7 @@ class Field extends DataTables\Ext
 	/** @var mixed */
 	private $_setValue;
 
-	/** @var mixed */
+	/** @var array[] */
 	private $_validator = array();
 
 	/** @var Upload */
@@ -871,7 +871,7 @@ class Field extends DataTables\Ext
 	 * (get or set).
 	 *
 	 * @param mixed    $val       Value to be formatted
-	 * @param mixed    $data      Full row data
+	 * @param array    $data      Full row data
 	 * @param callable $formatter Formatting function to be called
 	 * @param array    $opts      Array of options to be passed to the formatter
 	 *

--- a/Editor/Field.php
+++ b/Editor/Field.php
@@ -932,8 +932,6 @@ class Field extends DataTables\Ext
 	 * @param array  $data Data source array to read from
 	 *
 	 * @return bool `true` if present, `false` otherwise
-	 *
-	 * @private
 	 */
 	private function _inData($name, $data)
 	{

--- a/Editor/Field.php
+++ b/Editor/Field.php
@@ -315,7 +315,7 @@ class Field extends DataTables\Ext
 			// Options class
 			$this->_optsFn = null;
 			$this->_opts = $table;
-		} elseif (is_callable($table) && is_object($table)) {
+		} elseif ($table instanceof \Closure) {
 			// Function
 			$this->_opts = null;
 			$this->_optsFn = $table;
@@ -360,7 +360,7 @@ class Field extends DataTables\Ext
 			// Options class
 			$this->_spoptsFn = null;
 			$this->_spopts = $spInput;
-		} elseif (is_callable($spInput) && is_object($spInput)) {
+		} elseif ($spInput instanceof \Closure) {
 			// Function
 			$this->_spopts = null;
 			$this->_spoptsFn = $spInput;
@@ -387,7 +387,7 @@ class Field extends DataTables\Ext
 			// Options class
 			$this->_sboptsFn = null;
 			$this->_sbopts = $sbInput;
-		} elseif (is_callable($sbInput) && is_object($sbInput)) {
+		} elseif ($spInput instanceof \Closure) {
 			// Function
 			$this->_sbopts = null;
 			$this->_sboptsFn = $sbInput;
@@ -918,7 +918,7 @@ class Field extends DataTables\Ext
 	 */
 	private function _getAssignedValue($val)
 	{
-		return is_callable($val) && is_object($val) ?
+		return $val instanceof \Closure ?
 			$val() :
 			$val;
 	}

--- a/Editor/Join.php
+++ b/Editor/Join.php
@@ -241,7 +241,7 @@ class Join extends DataTables\Ext
 	 *                                link table.
 	 * @param string          $table  Join table name, if using a link table
 	 *
-	 * @returns Join This for chaining
+	 * @return Join This for chaining
 	 *
 	 * @deprecated 1.5 Please use the {@see Join->link()} method rather than this
 	 *                                method now.
@@ -989,7 +989,7 @@ class Join extends DataTables\Ext
 	 *
 	 * @param string $direction Direction: 'get' or 'set'.
 	 *
-	 * @returns array Fields to include
+	 * @return array Fields to include
 	 */
 	private function _fields($direction)
 	{

--- a/Editor/Join.php
+++ b/Editor/Join.php
@@ -121,7 +121,7 @@ class Join extends DataTables\Ext
 	/** @var string */
 	private $_customOrder;
 
-	/** @var callable[] */
+	/** @var array */
 	private $_validators = array();
 
 	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *

--- a/Editor/Join.php
+++ b/Editor/Join.php
@@ -807,8 +807,6 @@ class Join extends DataTables\Ext
 	 * Add local WHERE condition to query.
 	 *
 	 * @param \DataTables\Database\Query $query Query instance to apply the WHERE conditions to
-	 *
-	 * @private
 	 */
 	private function _apply_where($query)
 	{
@@ -831,8 +829,6 @@ class Join extends DataTables\Ext
 	 * @param \DataTables\Database $db       Database reference to use
 	 * @param int                  $parentId Parent row's primary key value
 	 * @param string[]             $data     Data to be set for the join
-	 *
-	 * @private
 	 */
 	private function _insert($db, $parentId, $data)
 	{
@@ -877,8 +873,6 @@ class Join extends DataTables\Ext
 	 * Prepare the instance to be run.
 	 *
 	 * @param Editor $editor Editor instance
-	 *
-	 * @private
 	 */
 	private function _prep($editor)
 	{
@@ -942,8 +936,6 @@ class Join extends DataTables\Ext
 	 * @param \DataTables\Database $db       Database reference to use
 	 * @param int                  $parentId Parent row's primary key value
 	 * @param string[]             $data     Data to be set for the join
-	 *
-	 * @private
 	 */
 	private function _update_row($db, $parentId, $data)
 	{
@@ -998,8 +990,6 @@ class Join extends DataTables\Ext
 	 * @param string $direction Direction: 'get' or 'set'.
 	 *
 	 * @returns array Fields to include
-	 *
-	 * @private
 	 */
 	private function _fields($direction)
 	{

--- a/Editor/Join.php
+++ b/Editor/Join.php
@@ -443,7 +443,7 @@ class Join extends DataTables\Ext
 			return $this->_where;
 		}
 
-		if (is_callable($key) && is_object($key)) {
+		if ($key instanceof \Closure) {
 			$this->_where[] = $key;
 		} else {
 			$this->_where[] = array(

--- a/Editor/Upload.php
+++ b/Editor/Upload.php
@@ -663,7 +663,7 @@ class Upload extends DataTables\Ext
 					$val = $prop;
 
 					// Callable function - execute to get the value
-					if (is_callable($prop) && is_object($prop)) {
+					if ($prop instanceof \Closure) {
 						$val = $prop($db, $upload);
 					}
 

--- a/Ext.php
+++ b/Ext.php
@@ -107,8 +107,6 @@ class Ext
 	 * @param array  $data Data source array to read from
 	 *
 	 * @return bool true if present, false otherwise
-	 *
-	 * @private
 	 */
 	protected function _propExists($name, $data)
 	{
@@ -146,8 +144,6 @@ class Ext
 	 * @param array  $data Data source array to read from
 	 *
 	 * @return mixed The read value, or null if no value found.
-	 *
-	 * @private
 	 */
 	protected function _readProp($name, $data)
 	{
@@ -190,8 +186,6 @@ class Ext
 	 * @param array  &$out  Array to write the data to
 	 * @param string $name  Javascript dotted object name to write to
 	 * @param mixed  $value Value to write
-	 *
-	 * @private
 	 */
 	protected function _writeProp(&$out, $name, $value)
 	{


### PR DESCRIPTION
extracted from #29

explained in https://github.com/DataTables/Editor-PHP/pull/29#issuecomment-1837562483 - I belive the changes are equivalent

also remove useless `@private` phpdoc tags above private methods

this PR should to fine to merge now even if the CI phpstan cannot confirm the changes currently, more CI fixes will be done in #31