### PR TITLE
Performance fix: removing unnecessary sql queries checking if selecte…

### DIFF
--- a/Editor.php
+++ b/Editor.php
@@ -1911,40 +1911,6 @@ class Editor extends Ext
 			// For every selection in every column
 			foreach ($this->_fields as $field) {
 				if (isset($http['searchPanes'][$field->name()])) {
-					for ($i = 0; $i < count($http['searchPanes'][$field->name()]); ++$i) {
-						// Check the number of rows...
-						$q = $db
-							->query('select')
-							->table($this->_table)
-							->get('COUNT(*) as cnt');
-
-						$q->left_join($this->_leftJoin);
-
-						// ... where the selected option is present...
-						if (
-							isset($http['searchPanes_null'][$field->name()][$i])
-							&& $http['searchPanes_null'][$field->name()][$i] === 'true'
-						) {
-							$q->where($field->dbField(), null, '=');
-						} else {
-							$q->where(
-								$field->dbField(),
-								$http['searchPanes'][$field->name()][$i],
-								'='
-							);
-						}
-
-						$r = $q
-							->exec()
-							->fetchAll();
-
-						// ... If there are none then don't bother with this selection
-						if ($r[0]['cnt'] == 0) {
-							array_splice($http['searchPanes'][$field->name()], $i, 1);
-							--$i;
-						}
-					}
-
 					$query->where(static function ($q) use ($field, $http) {
 						for ($j = 0; $j < count($http['searchPanes'][$field->name()]); ++$j) {
 							if (


### PR DESCRIPTION
It looks like those count queries are not needed. Even if we provide value, which is not in database, or_where will add 0 records to actual query result and it would be transparent for user. Removing those queries significantly increase performance and reduce number of sql queries. Variable $http is not used as reference anywhere, so its value inside doesn't have further impacts.